### PR TITLE
The rawest, most basic iml generation rule + java util

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bazel-*
 intellij-out
 workspace.xml
 preferred-vcs.xml
+extension/out

--- a/extension/.idea/modules.xml
+++ b/extension/.idea/modules.xml
@@ -3,6 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/extension.iml" filepath="$PROJECT_DIR$/extension.iml" />
+      <module fileurl="file:///private/var/tmp/_bazel_steveconover/75e504d5d7c4c7b3fa28edc9a5be5ca0/execroot/__main__/bazel-out/darwin_x86_64-fastbuild/bin/extension_root.iml" filepath="/private/var/tmp/_bazel_steveconover/75e504d5d7c4c7b3fa28edc9a5be5ca0/execroot/__main__/bazel-out/darwin_x86_64-fastbuild/bin/extension_root.iml" />
     </modules>
   </component>
 </project>

--- a/extension/.idea/runConfigurations/Main.xml
+++ b/extension/.idea/runConfigurations/Main.xml
@@ -1,0 +1,22 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Main" type="Application" factoryName="Application" singleton="true" nameIsGenerated="true">
+    <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea">
+      <pattern>
+        <option name="PATTERN" value="intellij_generate.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <option name="MAIN_CLASS_NAME" value="intellij_generate.Main" />
+    <option name="VM_PARAMETERS" value="" />
+    <option name="PROGRAM_PARAMETERS" value="-cr . -iml /tmp/somewhere/foo.iml" />
+    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+    <option name="ALTERNATIVE_JRE_PATH" />
+    <option name="ENABLE_SWING_INSPECTOR" value="false" />
+    <option name="ENV_VARIABLES" />
+    <option name="PASS_PARENT_ENVS" value="true" />
+    <module name="extension" />
+    <envs />
+    <method />
+  </configuration>
+</component>

--- a/extension/BUILD
+++ b/extension/BUILD
@@ -7,3 +7,11 @@ java_binary(
         "@com_beust_jcommander//jar",
     ]
 )
+
+load("//:intellij_iml.bzl", "intellij_iml")
+
+intellij_iml(
+    name = "extension_root",
+    deps = ["//:intellij_generate"]
+)
+

--- a/extension/extension.iml
+++ b/extension/extension.iml
@@ -7,5 +7,14 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../../temp-deps/jcommander-1.72.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
   </component>
 </module>

--- a/extension/intellij_iml.bzl
+++ b/extension/intellij_iml.bzl
@@ -1,0 +1,29 @@
+def _impl(ctx):
+    sources_roots_args = []
+    for sources_root_attr in ctx.attr.sources_roots:
+        sources_roots_args.append("--sources-root")
+        sources_roots_args.append(sources_root_attr)
+
+    ctx.action(
+        executable = ctx.executable._intellij_generate,
+        arguments = [
+          "--content-root", ctx.build_file_path.replace("BUILD", ".")] + # consider making this overridable via a ctx.attr
+          sources_roots_args + [
+          "--iml-path", ctx.outputs.iml_file.path,
+        ],
+        outputs=[ctx.outputs.iml_file],
+        progress_message="Generating intellij iml file: %s" % ctx.outputs.iml_file.path)
+
+intellij_iml = rule(
+    implementation=_impl,
+
+    # project layout defaults all follow from the maven standard directory layout for a java project,
+    # see: https://maven.apache.org/guides/introduction/introduction-to-the-standard-directory-layout.html
+    attrs={
+      "_intellij_generate": attr.label(default=Label("//:intellij_generate"), executable=True, cfg="target"),
+      "deps": attr.label_list(doc="java targets, whose dependencies will be used to build the library section of the iml."),
+      "sources_roots": attr.string_list(default=["src/main/java"], doc="Intellij will mark each of these directories as a 'Sources Root'"),
+    },
+
+    outputs={"iml_file": "%{name}.iml"},
+)

--- a/extension/src/main/java/intellij_generate/Main.java
+++ b/extension/src/main/java/intellij_generate/Main.java
@@ -1,10 +1,181 @@
 package intellij_generate;
 
 import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
 
 public class Main {
+  public static final String CLASSLOADER_PREFIX_PATH = "CLASSLOADER_PREFIX_PATH";
+  @Parameter(
+    names = {"--content-root", "-cr"},
+    description = "Path, typically relative to the iml's MODULE_DIR. Intellij will " +
+      "present files under this directory as the module's apparent contents.")
+  private String contentRoot = null;
+
+  @Parameter(
+    names = {"--sources-root", "-sr"},
+    description = "Directories under the content root that should be marked as source roots, " +
+      "coloring the folder blue, and making Intellij treat appropriately-named files under that root as code, " +
+      "that is indexed and navigable and so on.")
+  private List<String> sourcesRoots = new ArrayList<>();
+
+  @Parameter(
+    names = {"--iml-path", "-iml"},
+    description = "The goal of this operation is to generate an iml file whose path is indicated by this parameter.")
+  private String imlPath = null;
+
   public static void main(String[] args) {
-    JCommander.newBuilder();
-    System.out.println("Hello from intellij_generate");
+    Main main = new Main();
+    JCommander.newBuilder()
+      .addObject(main)
+      .build()
+      .parse(args);
+    main.run();
+  }
+
+  public void run() {
+    String classloaderPrefixPath = System.getenv(CLASSLOADER_PREFIX_PATH);
+    checkState(classloaderPrefixPath != null, "env var CLASSLOADER_PREFIX_PATH must be present");
+
+    // 1) Walk the file tree rooted at CLASSLOADER_PREFIX_PATH
+    // 2) Filter down to any subdir/jars that are under "external"...
+    //    but exclude local_jdk from this.
+    // 3) Finally, remove the CLASSLOADER_PREFIX_PATH from the library file path.
+    //    this makes it so intellij can access consistently-available files laid
+    //    out in the same structure, but directly under the WORKSPACE root.
+    //
+    // Some precedent:
+    // https://github.com/bazelbuild/intellij/blob/master/aspect/intellij_info_impl.bzl#L48
+    //
+    // The bazel java_binary wrapper script template:
+    // https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
+    //
+    // Also see the bazel java_stub_template, which is what hands us the CLASSLOADER_PREFIX_PATH
+    // env var.
+    //
+    // The approach used here is likely too brittle, and may be improved by making use of other
+    // representations of the same information (e.g. from a MANIFEST file...however the MANIFEST
+    // referred to in the above link is not available at runtime).
+    //
+    // I was also a little unsure about effectively treating the bazel output dirs as a public
+    // interface, however the bazelbuild/intellij reference, as well as the existence of documentation
+    // about the output dir structure:
+    // https://docs.bazel.build/versions/master/output_directories.html
+    // convinced me it's not terrible to do.
+    List<LibraryEntry> libraryEntries =
+      classloaderPrefixPathFileTree(classloaderPrefixPath).stream()
+        .filter(f -> f.startsWith(classloaderPrefixPath + "external") &&
+          !f.startsWith(classloaderPrefixPath + "external/local_jdk"))
+        .map(f -> new LibraryEntry(f.replace(classloaderPrefixPath, ""), f))
+        .collect(toList());
+
+    Path pathOfImlDir = Paths.get(new File(imlPath).getParent()).toAbsolutePath();
+    Path pathOfContentRoot = Paths.get(contentRoot).toAbsolutePath();
+    String pathFromModuleDirToContentRoot = pathOfImlDir.relativize(pathOfContentRoot).toString();
+    String pathFromModuleDirToContentRootWithIntellijVariable =
+      format("$MODULE_DIR$/%s", pathFromModuleDirToContentRoot.replaceAll("/$", ""));
+
+    List<String> lines = new ArrayList<>();
+    lines.add("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+    lines.add("<module type=\"JAVA_MODULE\" version=\"4\">");
+    lines.add("  <component name=\"NewModuleRootManager\" inherit-compiler-output=\"true\">");
+    lines.add("    <exclude-output />");
+    lines.add(format("    <content url=\"%s\">", "file://" + pathFromModuleDirToContentRootWithIntellijVariable));
+    sourcesRoots.forEach(sourcesRoot ->
+      lines.add(format("      <sourceFolder url=\"%s\" isTestSource=\"false\" />",
+        "file://" + fileJoin(pathFromModuleDirToContentRootWithIntellijVariable, sourcesRoot))));
+    lines.add("    </content>");
+    lines.add("    <orderEntry type=\"jdk\" jdkName=\"1.8\" jdkType=\"JavaSDK\" />");
+    lines.add("    <orderEntry type=\"sourceFolder\" forTests=\"false\" />");
+
+    if (!libraryEntries.isEmpty()) {
+      libraryEntries.forEach(libraryEntry -> {
+        String libraryPath = "jar://" + fileJoin(pathFromModuleDirToContentRootWithIntellijVariable, libraryEntry.path);
+
+        lines.add("    <orderEntry type=\"module-library\">");
+        lines.add("      <library>");
+        lines.add("        <CLASSES>");
+        lines.add(format("          <root url=\"%s!/\" />", libraryPath));
+        lines.add("        </CLASSES>");
+        lines.add("        <JAVADOC />");
+        lines.add("        <SOURCES />");
+        lines.add("      </library>");
+        lines.add("    </orderEntry>");
+      });
+    }
+
+    lines.add("  </component>");
+    lines.add("</module>");
+
+    writeLinesToFileAsUTF8(imlPath, lines);
+  }
+
+  @Override
+  public String toString() {
+    return "Make an intellij iml file:\n" +
+      format("contentRoot=%s", contentRoot) + "\n" +
+      format("sourcesRoots=%s", sourcesRoots) + "\n" +
+      format("imlPath=%s", imlPath);
+  }
+
+  private static List<String> classloaderPrefixPathFileTree(String classloaderPrefixPath) {
+    try {
+      return Files.walk(Paths.get(classloaderPrefixPath))
+        .filter(Files::isRegularFile)
+        .map(f -> f.toString())
+        .collect(toList());
+    } catch (IOException ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+
+  private static class LibraryEntry {
+    public final String name;
+    public final String path;
+
+    public LibraryEntry(String name, String path) {
+      this.name = name;
+      this.path = path;
+    }
+
+    @Override
+    public String toString() {
+      return format("LibraryEntry[%s,%s]", name, path);
+    }
+  }
+
+  private static void writeLinesToFileAsUTF8(String path, List<String> lines) {
+    new File(new File(path).getParent()).mkdirs();
+    try {
+      System.out.println(
+        format(">> IML CONTENT START %s", path) + "\n" +
+          lines.stream().collect(Collectors.joining("\n")) + "\n" +
+          format("<< IML CONTENT FINISH %s", path));
+      Files.write(Paths.get(path), lines, StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static String fileJoin(String aPath, String bPath) {
+    return new File(aPath, bPath).getPath();
+  }
+
+  private static void checkState(boolean condition, String message) {
+    if (!condition) {
+      throw new IllegalStateException(message);
+    }
   }
 }


### PR DESCRIPTION
The goal was to bootstrap extension development in this project.
The build will now generate a valid iml file, which properly
includes the util code and references its jcommander jar
dependency.

command line util that writes a simple iml file
hello - new rule
conversion to ctx.action, WIP
gen first iml file
non-hard-coded, and properly defaulted, sources-roots
name the bzl file something sensible
really raw and basic, but working iml. needs cleanup and commenting, WIP
cleanup and commenting