### PR TITLE
Write some unit tests of the iml generation code. Also make tests run…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Use Intellij in "classic mode". Core intellij project files are generated via your bazel build.
+
 Inspired by `pants idea`.
 
 dotfile in, intellij config out

--- a/extension/BUILD
+++ b/extension/BUILD
@@ -27,14 +27,9 @@ java_binary(
 # (As it stands, intellij_iml is not allowed to depend on a java_test
 # target, or anyhing with testonly=True set.)
 
-java_binary(
-  name="intellij_generate_tests",
+java_library(
+  name="intellij_generate_tests_lib",
   srcs = glob(["src/test/java/**/*.java"]),
-  main_class="org.junit.platform.console.ConsoleLauncher",
-  args=[
-    "--select-package intellij_generate",
-    "--details verbose",
-  ],
   deps=[
     ":intellij_generate_lib",
     "@org_junit_jupiter_junit_jupiter_api//jar",
@@ -46,6 +41,21 @@ java_binary(
     "@org_junit_platform_junit_platform_runner//jar",
     "@org_opentest4j_opentest4j//jar",
   ],
+)
+
+java_test(
+  name="intellij_generate_tests",
+  main_class="org.junit.platform.console.ConsoleLauncher",
+  args=[
+    "--select-package intellij_generate",
+    "--details verbose",
+  ],
+  runtime_deps=[
+    ":intellij_generate_lib",
+    ":intellij_generate_tests_lib",
+    "@org_junit_jupiter_junit_jupiter_api//jar",
+  ],
+  use_testrunner=False,
 )
 
 # TODO: consider whether a convenient module method is in order.
@@ -60,6 +70,6 @@ java_binary(
 load("//:intellij_iml.bzl", "intellij_iml")
 intellij_iml(
     name = "extension_root",
-    source_deps = [":intellij_generate"], # TODO: consider whether declaring this dependency explicitly is a good idea.
-    test_deps = [":intellij_generate_tests"],
+    source_deps = [":intellij_generate_lib"], # TODO: consider whether declaring this dependency explicitly is a good idea.
+    test_deps = [":intellij_generate_tests_lib"],
 )

--- a/extension/intellij_iml.bzl
+++ b/extension/intellij_iml.bzl
@@ -1,16 +1,31 @@
 def _prepare_library_manifest_file_from_java_runtime_classpath_info(ctx, java_deps, manifest_file_name):
+    """Given a bazel rule ctx, a list of java dependency labels,
+       find all java jar libraries for the dependencies,
+       and list them in a manifest file consisting of two columns:
+       column 1: the bazel name for the library
+       column 2: the path to the jar file
+    """
     library_manifest_content = ""
     for dep in java_deps:
-        library_path_prefix = dep.files_to_run.runfiles_manifest.dirname + "/" + ctx.workspace_name
         for cp_item in dep.java.compilation_info.runtime_classpath.to_list():
             if cp_item.is_source:
-                library_manifest_content += "%s %s/%s\n" % (cp_item.owner, library_path_prefix, cp_item.path)
+                # I would LOVE to make aboslute paths to java libs RIGHT HERE, vs figure out the
+                # paths via a java env hack, but I literally cannot. I object to this because:
+                # a) what I'm doing here is safe - there is no practical problem with allowing outside references to
+                #    files under execRoot, because execRoot is stable, and this has nothing to do with anything
+                #    hermetically-relevant.
+                # b) precedent has been set: genfiles dir, and files_to_run paths are both available in skylark-land.
+                # Anyway, see the java code for the super-ugly hack to determine execRoot.
+                library_manifest_content += "%s %s\n" % (cp_item.owner, cp_item.path)
 
     library_manifest_file = ctx.actions.declare_file(manifest_file_name)
     ctx.actions.write(output=library_manifest_file, content=library_manifest_content)
     return library_manifest_file
 
 def _impl(ctx):
+    """Based on ctx.attr inputs, invoke the iml-generating executable, and write the result to the designated iml path."""
+    # print(ctx.var)
+
     sources_roots_args = []
     for sources_root_attr in ctx.attr.sources_roots:
         sources_roots_args.append("--sources-root")
@@ -42,10 +57,14 @@ def _impl(ctx):
         progress_message="Generating intellij iml file: %s" % ctx.outputs.iml_file.path)
 
 intellij_iml = rule(
+    doc="""Generate an intellij iml file, containing:
+            - module library entries that point to jar and module dependencies, as known by bazel
+            - (user-specified) source and test roots, that default to the standard maven project layout
+            (see: https://maven.apache.org/guides/introduction/introduction-to-the-standard-directory-layout.html)
+            (TODO: document further)
+        """,
     implementation=_impl,
 
-    # project layout defaults all follow from the maven standard directory layout for a java project,
-    # see: https://maven.apache.org/guides/introduction/introduction-to-the-standard-directory-layout.html
     attrs={
       "_intellij_generate": attr.label(default=Label("//:intellij_generate"), executable=True, cfg="target"),
 

--- a/extension/src/main/java/intellij_generate/ImlContent.java
+++ b/extension/src/main/java/intellij_generate/ImlContent.java
@@ -1,0 +1,88 @@
+package intellij_generate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static intellij_generate.Util.fileJoin;
+import static java.lang.String.format;
+
+public class ImlContent {
+  static String makeImlContent(
+    String pathFromModuleDirToContentRoot,
+    List<String> sourcesRoots,
+    List<String> testSourcesRoots,
+    List<JarLibraryEntry> mainLibraryEntries,
+    List<JarLibraryEntry> testLibraryEntries) {
+
+    String pathFromModuleDirToContentRootWithIntellijVariable =
+      format("$MODULE_DIR$/%s", pathFromModuleDirToContentRoot.replaceAll("/$", ""));
+
+    List<String> lines = new ArrayList<>();
+    lines.add("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+    lines.add("<module type=\"JAVA_MODULE\" version=\"4\">");
+    lines.add("  <component name=\"NewModuleRootManager\" inherit-compiler-output=\"true\">");
+    lines.add("    <exclude-output />");
+
+    lines.add(format("    <content url=\"%s\">", "file://" + pathFromModuleDirToContentRootWithIntellijVariable));
+
+    sourcesRoots.forEach(sourcesRoot ->
+      lines.add(format("      <sourceFolder url=\"%s\" isTestSource=\"false\" />",
+        "file://" + fileJoin(pathFromModuleDirToContentRootWithIntellijVariable, sourcesRoot))));
+
+    testSourcesRoots.forEach(testSourcesRoot ->
+      lines.add(format("      <sourceFolder url=\"%s\" isTestSource=\"true\" />",
+        "file://" + fileJoin(pathFromModuleDirToContentRootWithIntellijVariable, testSourcesRoot))));
+
+    lines.add("    </content>");
+
+    lines.add("    <orderEntry type=\"jdk\" jdkName=\"1.8\" jdkType=\"JavaSDK\" />");
+    lines.add("    <orderEntry type=\"sourceFolder\" forTests=\"false\" />");
+
+    if (!mainLibraryEntries.isEmpty()) {
+      mainLibraryEntries.forEach(
+        jarLibraryEntry ->
+          addLibraryOrderEntryLines(
+            lines,
+            jarLibraryEntry));
+    }
+
+    if (!testLibraryEntries.isEmpty()) {
+      testLibraryEntries.forEach(
+        jarLibraryEntry ->
+          addLibraryOrderEntryLines(
+            lines,
+            jarLibraryEntry,
+            " scope=\"TEST\""));
+    }
+
+    lines.add("  </component>");
+    lines.add("</module>");
+
+    return lines.stream().collect(Collectors.joining("\n"));
+  }
+
+  private static void addLibraryOrderEntryLines(List<String> lines, JarLibraryEntry jarLibraryEntry) {
+    addLibraryOrderEntryLines(
+      lines,
+      jarLibraryEntry,
+      "");
+  }
+
+  private static void addLibraryOrderEntryLines(
+    List<String> lines,
+    JarLibraryEntry jarLibraryEntry,
+    String extraOrderEntryAttributes) {
+    String libraryPath = "jar://" + jarLibraryEntry.path;
+
+    lines.add(format("    <orderEntry type=\"module-library\"%s>", extraOrderEntryAttributes));
+    lines.add("      <library>");
+    lines.add("        <CLASSES>");
+    lines.add(format("          <root url=\"%s!/\" />", libraryPath));
+    lines.add("        </CLASSES>");
+    lines.add("        <JAVADOC />");
+    lines.add("        <SOURCES />");
+    lines.add("      </library>");
+    lines.add("    </orderEntry>");
+  }
+}

--- a/extension/src/main/java/intellij_generate/JarLibraryEntry.java
+++ b/extension/src/main/java/intellij_generate/JarLibraryEntry.java
@@ -1,0 +1,45 @@
+package intellij_generate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static intellij_generate.Util.fileJoin;
+import static intellij_generate.Util.readFile;
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Represents an entry from a manifest file provided by the bazel build to the iml-generator.
+ * The manifest file consists of two columns: name and path-on-disk-to-the-jar-file.
+ */
+public class JarLibraryEntry {
+  static List<JarLibraryEntry> loadLibraryEntriesFromManifestFile(String execRootPath, String librariesManifestPath) {
+    String fileContent = readFile(librariesManifestPath);
+    if (fileContent.trim().length() == 0) {
+      return new ArrayList<>();
+    } else {
+      return asList(fileContent.split("\n")).stream()
+        .map(line -> {
+          String[] parts = line.split(" ");
+          String name = parts[0];
+          String path = parts[1];
+          return new JarLibraryEntry(name, fileJoin(execRootPath, path));
+        })
+        .collect(toList());
+    }
+  }
+
+  public final String name;
+  public final String path;
+
+  public JarLibraryEntry(String name, String path) {
+    this.name = name;
+    this.path = path;
+  }
+
+  @Override
+  public String toString() {
+    return format("JarLibraryEntry[%s,%s]", name, path);
+  }
+}

--- a/extension/src/main/java/intellij_generate/Util.java
+++ b/extension/src/main/java/intellij_generate/Util.java
@@ -6,20 +6,18 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 
 public class Util {
-  static void writeLinesToFileAsUTF8(String path, List<String> lines) {
+  static void writeStringToFileAsUTF8(String path, String content) {
     new File(new File(path).getParent()).mkdirs();
     try {
       System.out.println(
         format(">> IML CONTENT START %s", path) + "\n" +
-          lines.stream().collect(Collectors.joining("\n")) + "\n" +
+          content + "\n" +
           format("<< IML CONTENT FINISH %s", path));
-      Files.write(Paths.get(path), lines, StandardCharsets.UTF_8);
+      Files.write(Paths.get(path), content.getBytes(StandardCharsets.UTF_8));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -28,9 +26,7 @@ public class Util {
   static String readFile(String pathStr) {
     try {
       checkState(pathStr != null, "expected file path to be non-null");
-      Path pathObject = Paths.get(pathStr);
-      checkState(pathObject.toFile().exists(), format("expected file path to exist %s", pathStr));
-      return new String(Files.readAllBytes(pathObject));
+      return new String(Files.readAllBytes(checkPathExists(Paths.get(pathStr))));
     } catch (IOException ex) {
       throw new RuntimeException(ex);
     }
@@ -40,9 +36,14 @@ public class Util {
     return new File(aPath, bPath).getPath();
   }
 
-  private static void checkState(boolean condition, String message) {
+  static void checkState(boolean condition, String message) {
     if (!condition) {
       throw new IllegalStateException(message);
     }
+  }
+
+  static Path checkPathExists(Path path) {
+    checkState(path.toFile().exists(), format("expected path to exist: %s", path));
+    return path;
   }
 }

--- a/extension/src/test/java/intellij_generate/ImlContentTest.java
+++ b/extension/src/test/java/intellij_generate/ImlContentTest.java
@@ -1,0 +1,62 @@
+package intellij_generate;
+
+import org.junit.jupiter.api.Test;
+
+import static intellij_generate.ImlContent.makeImlContent;
+import static intellij_generate.TestUtil.xpath;
+import static intellij_generate.TestUtil.xpathList;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ImlContentTest {
+  @Test
+  public void makes_content_root() {
+    String imlContent =
+      makeImlContent(
+        "../../this-is-the-content-dir",
+        emptyList(), emptyList(), emptyList(), emptyList());
+
+    assertEquals(
+      "file://$MODULE_DIR$/../../this-is-the-content-dir",
+      xpath(imlContent, "/module/component/content/@url"));
+  }
+
+  @Test
+  public void makes_sources_roots_within_content_root() {
+    String imlContent =
+      makeImlContent(
+        "../../this-is-the-content-dir",
+        asList("foosrc/main/java", "barsrc/main/java"), emptyList(), emptyList(), emptyList());
+
+    assertEquals(asList(
+      "file://$MODULE_DIR$/../../this-is-the-content-dir/foosrc/main/java",
+      "file://$MODULE_DIR$/../../this-is-the-content-dir/barsrc/main/java"),
+      xpathList(imlContent, "/module/component/content/sourceFolder/@url"));
+
+    assertEquals(
+      asList("false", "false"),
+      xpathList(imlContent, "/module/component/content/sourceFolder/@isTestSource"));
+  }
+
+  @Test
+  public void makes_test_roots_within_content_root() {
+    String imlContent =
+      makeImlContent(
+        "../../this-is-the-content-dir",
+        emptyList(), asList("foosrc/test/java", "barsrc/test/java"), emptyList(), emptyList());
+
+    assertEquals(asList(
+      "file://$MODULE_DIR$/../../this-is-the-content-dir/foosrc/test/java",
+      "file://$MODULE_DIR$/../../this-is-the-content-dir/barsrc/test/java"),
+      xpathList(imlContent, "/module/component/content/sourceFolder/@url"));
+
+    assertEquals(
+      asList("true", "true"),
+      xpathList(imlContent, "/module/component/content/sourceFolder/@isTestSource"));
+  }
+
+  //TODO: what about src lib, test lib overlap? warn, w/ test-wins? how to communicate back warnings
+  // ...just return them and use stderr in Main?
+  //TODO: src libs, test libs, also overlap bug
+}

--- a/extension/src/test/java/intellij_generate/TestUtil.java
+++ b/extension/src/test/java/intellij_generate/TestUtil.java
@@ -1,0 +1,77 @@
+package intellij_generate;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathFactory;
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static intellij_generate.Util.checkState;
+import static java.lang.String.format;
+
+public class TestUtil {
+  static List<String> xpathList(String xmlDocument, String xpath) {
+    NodeList nodeList = xpathNodeListFromDoc(xpath, parseXml(xmlDocument));
+    List<String> results = new ArrayList<>();
+    for (int i = 0; i < nodeList.getLength(); i++) {
+      results.add(nodeList.item(i).getTextContent());
+    }
+    return results;
+  }
+
+  static String xpath(String xmlDocument, String xpath) {
+    NodeList nodeList = xpathNodeListFromDoc(xpath, parseXml(xmlDocument));
+    checkState(nodeList.getLength() == 1,
+      format("expected number of results for xpath text result query to be exactly 1, " +
+        "but was %d, results: %s", nodeList.getLength(), nodeList));
+    return nodeList.item(0).getTextContent();
+  }
+
+  private static Document parseXml(String xmlString) {
+    try {
+      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      factory.setIgnoringElementContentWhitespace(true);
+      DocumentBuilder builder = factory.newDocumentBuilder();
+      builder.setErrorHandler(new ErrorHandler() {
+        @Override
+        public void warning(SAXParseException exception) throws SAXException {
+          // silence SAX parse warnings
+        }
+
+        @Override
+        public void error(SAXParseException exception) throws SAXException {
+          // silence SAX parse errors
+        }
+
+        @Override
+        public void fatalError(SAXParseException exception) throws SAXException {
+          throw exception;
+        }
+      });
+      return builder.parse(new ByteArrayInputStream(xmlString.getBytes()));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static NodeList xpathNodeListFromDoc(String xpathExpression, Document doc) {
+    try {
+      XPathFactory xPathfactory = XPathFactory.newInstance();
+      XPath xpath = xPathfactory.newXPath();
+      XPathExpression expr = xpath.compile(xpathExpression);
+      return (NodeList) expr.evaluate(doc, XPathConstants.NODESET);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/extension/tools/bazel.rc
+++ b/extension/tools/bazel.rc
@@ -1,0 +1,1 @@
+test --test_output=errors --action_env="GTEST_COLOR=1"


### PR DESCRIPTION
… via bazel test. Involves compromises to determine execution_root.

refactoring in preparation for unit tests
test content root
tests for content root and regular and test sources
todo's
spacing and xml warning cleanup
improvements, also an evil hack to get at execroot, so we can use intellij_iml for java_library targets
now that intellij can be gen'd based on java_library targets, separate out java_test targets and make it so tests run in ide and build. yay