### PR TITLE
Shell scripts that install compiler.xml and modules.xml

### DIFF
--- a/scenarios/05_annotation_processor/.idea/compiler.xml
+++ b/scenarios/05_annotation_processor/.idea/compiler.xml
@@ -1,1 +1,1 @@
-../../bazel-out/darwin_x86_64-fastbuild/bin/05_annotation_processor/idea_annotation_processors_compiler.xml
+../../bazel-scenarios/bazel-out/darwin_x86_64-fastbuild/bin/05_annotation_processor/idea_annotation_processors_compiler.xml

--- a/scenarios/05_annotation_processor/.idea/modules.xml
+++ b/scenarios/05_annotation_processor/.idea/modules.xml
@@ -1,1 +1,1 @@
-../../bazel-bin/05_annotation_processor/idea_project_modules.xml
+../../bazel-scenarios/bazel-out/darwin_x86_64-fastbuild/bin/05_annotation_processor/idea_project_modules.xml

--- a/scenarios/scenario_tests/.idea/modules.xml
+++ b/scenarios/scenario_tests/.idea/modules.xml
@@ -1,1 +1,1 @@
-../../bazel-out/darwin_x86_64-fastbuild/bin/scenario_tests/idea_project_modules.xml
+../../bazel-scenarios/bazel-out/darwin_x86_64-fastbuild/bin/scenario_tests/idea_project_modules.xml


### PR DESCRIPTION
They symlink down into the compiler.xml / modules.xml files
created by a bazel run.

modules.xml installer script
compiler.xml installer script
add --force flags to scripts