### PR TITLE
New bazel target naming system and some other cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,23 @@ Primary Goals:
   - src/main/java, src/main/test
   - relatively coarse-grained modules
 - testing: various real-ish scenarios are present in this project, and usable.
+
+
+Bazel Target Naming Conventions
+
+A lot fot hese are repeated across modules, and bazel module scoping
+provides enough namespacing information that it's redundant and arguably
+confusing to repeat the namespace in such target names. This system
+also has the benefits of being consistent horizontally and therefore
+is easily grep-able and so on.
+
+- main code for module: "lib"
+- test code for module: "test_lib"
+- executable test tasks: "tests"
+- proto: "proto"
+- java proto codegen: "proto_java"
+- grpc: "grpc"
+- idea iml module: "iml"
+- idea modules.xml: "modules_xml"
+- idea compiler.xml: "compiler_xml"
+- idea project: "idea_project"

--- a/rules/private/BUILD
+++ b/rules/private/BUILD
@@ -1,37 +1,37 @@
-package(default_visibility = ["//:__subpackages__"])
+package(default_visibility = ["//private:__subpackages__"])
 
-java_library(
-    name = "intellij_generate_lib",
-    srcs = glob(["src/main/java/**/*.java"]),
-    deps = [
-        "@com_beust_jcommander//jar",
-    ]
-)
+# === EXPORTS ===
 
 java_binary(
     name = "intellij_generate_iml",
     main_class = "intellij_generate.iml.Main",
     visibility = ["//visibility:public"],
-    runtime_deps = [
-        ":intellij_generate_lib",
-    ]
+    runtime_deps = [":lib"]
 )
 
 java_binary(
     name = "intellij_generate_modules_xml",
     main_class = "intellij_generate.modules_xml.Main",
     visibility = ["//visibility:public"],
-    runtime_deps = [
-        ":intellij_generate_lib",
-    ]
+    runtime_deps = [":lib"]
 )
 
 java_binary(
     name = "intellij_generate_compiler_xml",
     main_class = "intellij_generate.compiler_xml.Main",
     visibility = ["//visibility:public"],
-    runtime_deps = [
-        ":intellij_generate_lib",
+    runtime_deps = [":lib"]
+)
+
+
+
+# === PRIVATE ===
+
+java_library(
+    name = "lib",
+    srcs = glob(["src/main/java/**/*.java"]),
+    deps = [
+        "@com_beust_jcommander//jar",
     ]
 )
 
@@ -39,10 +39,10 @@ java_binary(
 # automatically (without explicitly specifying a package), or from a directory or something.
 
 java_library(
-  name="intellij_generate_tests_lib",
+  name="test_lib",
   srcs = glob(["src/test/java/**/*.java"]),
   deps=[
-    ":intellij_generate_lib",
+    ":lib",
 
     "@org_junit_jupiter_junit_jupiter_api//jar",
     "@org_opentest4j_opentest4j//jar",
@@ -51,11 +51,11 @@ java_library(
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
 junit5_all_in_package_test(
-    name="intellij_generate_tests",
+    name="tests",
     java_package="intellij_generate",
     runtime_deps=[
-        ":intellij_generate_lib",
-        ":intellij_generate_tests_lib",
+        ":lib",
+        ":test_lib",
     ]
 )
 
@@ -69,19 +69,19 @@ exports_files([
 
 load(":intellij_iml.bzl", "intellij_iml")
 intellij_iml(
-    name = "idea_rules_private_module",
-    compile_lib_deps = [":intellij_generate_lib"],
-    test_lib_deps = [":intellij_generate_tests_lib"],
+    name = "iml",
+    compile_lib_deps = [":lib"],
+    test_lib_deps = [":test_lib"],
 )
 
 load(":intellij_modules_xml.bzl", "intellij_modules_xml")
 intellij_modules_xml(
-    name = "idea_rules_private_modules",
-    deps = [":idea_rules_private_module"]
+    name = "modules_xml",
+    deps = [":iml"]
 )
 
 load(":intellij_project.bzl", "intellij_project")
 intellij_project(
-  name="rulesproj",
-  intellij_modules_xml=":idea_rules_private_modules",
+  name="idea_project",
+  intellij_modules_xml=":modules_xml",
 )

--- a/scenarios/01_one_class/BUILD
+++ b/scenarios/01_one_class/BUILD
@@ -1,33 +1,34 @@
-package(default_visibility = ["//:__subpackages__"])
+package(default_visibility = ["//01_one_class:__subpackages__"])
 
 java_library(
-    name = "one_class",
+    name = "lib",
     srcs = glob(["src/**/*.java"]),
 )
 
 java_binary(
-    name = "one_class_run",
+    name = "run_A",
     main_class="oneclass.A",
     srcs = glob(["src/**/*.java"]),
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")
 intellij_iml(
-    name = "idea_root_module",
+    name = "iml",
     sources_roots = ["src"],
-    compile_lib_deps = [":one_class"],
+    compile_lib_deps = [":lib"],
     test_sources_roots = [],
     test_lib_deps = [],
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_modules_xml")
 intellij_modules_xml(
-    name = "01modules",
-    deps = [":idea_root_module"]
+    name = "modules_xml",
+    deps = [":iml"]
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_project")
 intellij_project(
-  name="01proj",
-  intellij_modules_xml=":01modules",
+  name="idea_project",
+  intellij_modules_xml=":modules_xml",
+  visibility=["//:__subpackages__"],
 )

--- a/scenarios/02_one_class_and_one_test/BUILD
+++ b/scenarios/02_one_class_and_one_test/BUILD
@@ -1,15 +1,15 @@
-package(default_visibility = ["//:__subpackages__"])
+package(default_visibility = ["//02_one_class_and_one_test:__subpackages__"])
 
 java_library(
-    name = "one_class_and_one_test",
+    name = "lib",
     srcs = glob(["src/**/*.java"]),
 )
 
 java_library(
-    name = "one_class_and_one_test_tests_lib",
+    name = "test_lib",
     srcs = glob(["test/**/*.java"]),
     deps=[
-      ":one_class_and_one_test",
+      ":lib",
 
       "@org_junit_jupiter_junit_jupiter_api//jar",
       "@org_opentest4j_opentest4j//jar",
@@ -18,28 +18,29 @@ java_library(
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
 junit5_all_in_package_test(
-    name="one_class_and_one_test_tests",
+    name="tests",
     java_package="one_class_and_one_test",
-    runtime_deps=[":one_class_and_one_test_tests_lib"]
+    runtime_deps=[":test_lib"]
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")
 intellij_iml(
-    name = "idea_root_module",
+    name = "iml",
     sources_roots = ["src"],
-    compile_lib_deps = [":one_class_and_one_test"],
+    compile_lib_deps = [":lib"],
     test_sources_roots = ["test"],
-    test_lib_deps = [":one_class_and_one_test_tests_lib"],
+    test_lib_deps = [":test_lib"],
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_modules_xml")
 intellij_modules_xml(
-    name = "02modules",
-    deps = [":idea_root_module"]
+    name = "modules_xml",
+    deps = [":iml"]
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_project")
 intellij_project(
-  name="02proj",
-  intellij_modules_xml=":02modules",
+  name="idea_project",
+  intellij_modules_xml=":modules_xml",
+  visibility=["//:__subpackages__"],
 )

--- a/scenarios/03_basic/BUILD
+++ b/scenarios/03_basic/BUILD
@@ -1,17 +1,18 @@
-package(default_visibility = ["//:__subpackages__"])
+package(default_visibility = ["//03_basic:__subpackages__"])
 
 load("@rules_intellij_generate//:def.bzl", "intellij_modules_xml")
 intellij_modules_xml(
-    name = "03modules",
+    name = "modules_xml",
     deps = [
-      "//03_basic/dolphin:idea_dolphin_module",
-      "//03_basic/gorilla:idea_gorilla_module",
-      "//03_basic/human:idea_human_module",
+      "//03_basic/dolphin:iml",
+      "//03_basic/gorilla:iml",
+      "//03_basic/human:iml",
     ]
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_project")
 intellij_project(
-  name="03proj",
-  intellij_modules_xml=":03modules",
+  name="idea_project",
+  intellij_modules_xml=":modules_xml",
+  visibility=["//:__subpackages__"],
 )

--- a/scenarios/03_basic/dolphin/BUILD
+++ b/scenarios/03_basic/dolphin/BUILD
@@ -1,19 +1,19 @@
 package(default_visibility = ["//03_basic:__subpackages__"])
 
 java_library(
-    name = "dolphin_lib",
+    name = "lib",
     srcs = glob(["src/main/java/**/*.java"]),
     deps=[
-      "//03_basic/mammal:mammal_lib",
+      "//03_basic/mammal:lib",
     ]
 )
 
 java_library(
-    name = "dolphin_tests_lib",
+    name = "test_lib",
     srcs = glob(["src/test/java/**/*.java"]),
     deps=[
-      ":dolphin_lib",
-      "//03_basic/mammal:mammal_lib",
+      ":lib",
+      "//03_basic/mammal:lib",
 
       "@org_junit_jupiter_junit_jupiter_api//jar",
       "@org_opentest4j_opentest4j//jar",
@@ -22,15 +22,15 @@ java_library(
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
 junit5_all_in_package_test(
-    name="dolphin_tests",
+    name="tests",
     java_package="basic.dolphin",
-    runtime_deps=[":dolphin_tests_lib"]
+    runtime_deps=[":test_lib"]
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")
 intellij_iml(
-    name = "idea_dolphin_module",
-    compile_lib_deps = [":dolphin_lib"],
-    compile_module_deps = ["//03_basic/mammal:idea_mammal_module"],
-    test_lib_deps = [":dolphin_tests_lib"],
+    name = "iml",
+    compile_lib_deps = [":lib"],
+    compile_module_deps = ["//03_basic/mammal:iml"],
+    test_lib_deps = [":test_lib"],
 )

--- a/scenarios/03_basic/gorilla/BUILD
+++ b/scenarios/03_basic/gorilla/BUILD
@@ -1,20 +1,20 @@
 package(default_visibility = ["//03_basic:__subpackages__"])
 
 java_library(
-    name = "gorilla_lib",
+    name = "lib",
     srcs = glob(["src/main/java/**/*.java"]),
     deps=[
-      "//03_basic/primate:primate_lib",
+      "//03_basic/primate:lib",
     ]
 )
 
 java_library(
-    name = "gorilla_tests_lib",
+    name = "test_lib",
     srcs = glob(["src/test/java/**/*.java"]),
     deps=[
-      ":gorilla_lib",
-      "//03_basic/primate:primate_lib",
-      "//03_basic/mammal:mammal_lib",
+      "lib",
+      "//03_basic/primate:lib",
+      "//03_basic/mammal:lib",
 
       "@org_junit_jupiter_junit_jupiter_api//jar",
       "@org_opentest4j_opentest4j//jar",
@@ -23,15 +23,15 @@ java_library(
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
 junit5_all_in_package_test(
-    name="gorilla_tests",
+    name="tests",
     java_package="basic.gorilla",
-    runtime_deps=[":gorilla_tests_lib"]
+    runtime_deps=[":test_lib"]
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")
 intellij_iml(
-    name = "idea_gorilla_module",
-    compile_lib_deps = [":gorilla_lib"],
-    compile_module_deps = ["//03_basic/primate:idea_primate_module"],
-    test_lib_deps = [":gorilla_tests_lib"],
+    name = "iml",
+    compile_lib_deps = [":lib"],
+    compile_module_deps = ["//03_basic/primate:iml"],
+    test_lib_deps = [":test_lib"],
 )

--- a/scenarios/03_basic/human/BUILD
+++ b/scenarios/03_basic/human/BUILD
@@ -1,20 +1,20 @@
 package(default_visibility = ["//03_basic:__subpackages__"])
 
 java_library(
-    name = "human_lib",
+    name = "lib",
     srcs = glob(["src/main/java/**/*.java"]),
     deps=[
-      "//03_basic/primate:primate_lib",
+      "//03_basic/primate:lib",
     ]
 )
 
 java_library(
-    name = "human_tests_lib",
+    name = "test_lib",
     srcs = glob(["src/test/java/**/*.java"]),
     deps=[
-      ":human_lib",
-      "//03_basic/primate:primate_lib",
-      "//03_basic/mammal:mammal_lib",
+      ":lib",
+      "//03_basic/primate:lib",
+      "//03_basic/mammal:lib",
 
       "@org_junit_jupiter_junit_jupiter_api//jar",
       "@org_opentest4j_opentest4j//jar",
@@ -23,17 +23,17 @@ java_library(
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
 junit5_all_in_package_test(
-    name="human_tests",
+    name="tests",
     java_package="basic.human",
-    runtime_deps=[":human_tests_lib"]
+    runtime_deps=[":test_lib"]
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")
 intellij_iml(
-    name = "idea_human_module",
-    compile_lib_deps = [":human_lib"],
+    name = "iml",
+    compile_lib_deps = [":lib"],
     compile_module_deps = [
-      "//03_basic/primate:idea_primate_module"
+      "//03_basic/primate:iml"
     ],
-    test_lib_deps = [":human_tests_lib"],
+    test_lib_deps = [":test_lib"],
 )

--- a/scenarios/03_basic/mammal/BUILD
+++ b/scenarios/03_basic/mammal/BUILD
@@ -1,15 +1,15 @@
 package(default_visibility = ["//03_basic:__subpackages__"])
 
 java_library(
-    name = "mammal_lib",
+    name = "lib",
     srcs = glob(["src/main/java/**/*.java"]),
 )
 
 java_library(
-    name = "mammal_tests_lib",
+    name = "test_lib",
     srcs = glob(["src/test/java/**/*.java"]),
     deps=[
-      ":mammal_lib",
+      ":lib",
 
       "@org_junit_jupiter_junit_jupiter_api//jar",
       "@org_opentest4j_opentest4j//jar",
@@ -18,14 +18,14 @@ java_library(
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
 junit5_all_in_package_test(
-    name="mammal_tests",
+    name="tests",
     java_package="basic.mammal",
-    runtime_deps=[":mammal_tests_lib"]
+    runtime_deps=[":lib"]
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")
 intellij_iml(
-    name = "idea_mammal_module",
-    compile_lib_deps = [":mammal_lib"],
-    test_lib_deps = [":mammal_tests_lib"],
+    name = "iml",
+    compile_lib_deps = [":lib"],
+    test_lib_deps = [":test_lib"],
 )

--- a/scenarios/03_basic/primate/BUILD
+++ b/scenarios/03_basic/primate/BUILD
@@ -1,19 +1,19 @@
 package(default_visibility = ["//03_basic:__subpackages__"])
 
 java_library(
-    name = "primate_lib",
+    name = "lib",
     srcs = glob(["src/main/java/**/*.java"]),
     deps=[
-      "//03_basic/mammal:mammal_lib",
+      "//03_basic/mammal:lib",
     ]
 )
 
 java_library(
-    name = "primate_tests_lib",
+    name = "test_lib",
     srcs = glob(["src/test/java/**/*.java"]),
     deps=[
-      ":primate_lib",
-      "//03_basic/mammal:mammal_lib",
+      ":lib",
+      "//03_basic/mammal:lib",
 
       "@org_junit_jupiter_junit_jupiter_api//jar",
       "@org_opentest4j_opentest4j//jar",
@@ -22,15 +22,15 @@ java_library(
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
 junit5_all_in_package_test(
-    name="primate_tests",
+    name="tests",
     java_package="basic.primate",
-    runtime_deps=[":primate_tests_lib"]
+    runtime_deps=[":test_lib"]
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")
 intellij_iml(
-    name = "idea_primate_module",
-    compile_lib_deps = [":primate_lib"],
-    compile_module_deps = ["//03_basic/mammal:idea_mammal_module"],
-    test_lib_deps = [":primate_tests_lib"],
+    name = "iml",
+    compile_lib_deps = [":lib"],
+    compile_module_deps = ["//03_basic/mammal:iml"],
+    test_lib_deps = [":lib"],
 )

--- a/scenarios/04_transitive_via_export/BUILD
+++ b/scenarios/04_transitive_via_export/BUILD
@@ -1,17 +1,18 @@
-package(default_visibility = ["//:__subpackages__"])
+package(default_visibility = ["//04_transitive_via_export:__subpackages__"])
 
 load("@rules_intellij_generate//:def.bzl", "intellij_modules_xml")
 intellij_modules_xml(
-    name = "04modules",
+    name = "modules_xml",
     deps = [
-      "//04_transitive_via_export/grandparent:idea_grandparent_module",
-      "//04_transitive_via_export/parent:idea_parent_module",
-      "//04_transitive_via_export/child:idea_child_module",
+      "//04_transitive_via_export/grandparent:iml",
+      "//04_transitive_via_export/parent:iml",
+      "//04_transitive_via_export/child:iml",
     ]
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_project")
 intellij_project(
-  name="04proj",
-  intellij_modules_xml=":04modules",
+  name="idea_project",
+  intellij_modules_xml=":modules_xml",
+  visibility=["//:__subpackages__"],
 )

--- a/scenarios/04_transitive_via_export/child/BUILD
+++ b/scenarios/04_transitive_via_export/child/BUILD
@@ -1,16 +1,16 @@
 package(default_visibility = ["//04_transitive_via_export:__subpackages__"])
 
 java_library(
-    name = "child_lib",
+    name = "lib",
     srcs = glob(["src/main/java/**/*.java"]),
-    deps = ["//04_transitive_via_export/parent:parent_lib"],
+    deps = ["//04_transitive_via_export/parent:lib"],
 )
 
 java_library(
-    name = "child_tests_lib",
+    name = "test_lib",
     srcs = glob(["src/test/java/**/*.java"]),
     deps=[
-      ":child_lib",
+      ":lib",
 
       "@org_junit_jupiter_junit_jupiter_api//jar",
       "@org_opentest4j_opentest4j//jar",
@@ -19,15 +19,15 @@ java_library(
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
 junit5_all_in_package_test(
-    name="child_tests",
+    name="tests",
     java_package="transitive_via_export.child",
-    runtime_deps=[":child_tests_lib"]
+    runtime_deps=[":test_lib"]
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")
 intellij_iml(
-    name = "idea_child_module",
-    compile_lib_deps = [":child_lib"],
-    compile_module_deps = ["//04_transitive_via_export/parent:idea_parent_module"],
-    test_lib_deps = [":child_tests_lib"],
+    name = "iml",
+    compile_lib_deps = [":lib"],
+    compile_module_deps = ["//04_transitive_via_export/parent:iml"],
+    test_lib_deps = [":test_lib"],
 )

--- a/scenarios/04_transitive_via_export/grandparent/BUILD
+++ b/scenarios/04_transitive_via_export/grandparent/BUILD
@@ -1,17 +1,17 @@
 package(default_visibility = ["//04_transitive_via_export:__subpackages__"])
 
 java_library(
-    name = "grandparent_lib",
+    name = "lib",
     srcs = glob(["src/main/java/**/*.java"]),
     deps = ["@com_google_guava_guava//jar"],
     exports = ["@com_google_guava_guava//jar"],
 )
 
 java_library(
-    name = "grandparent_tests_lib",
+    name = "test_lib",
     srcs = glob(["src/test/java/**/*.java"]),
     deps=[
-      ":grandparent_lib",
+      ":lib",
 
       "@org_junit_jupiter_junit_jupiter_api//jar",
       "@org_opentest4j_opentest4j//jar",
@@ -20,14 +20,14 @@ java_library(
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
 junit5_all_in_package_test(
-    name="grandparent_tests",
+    name="tests",
     java_package="transitive_via_export.grandparent",
-    runtime_deps=[":grandparent_tests_lib"]
+    runtime_deps=[":test_lib"]
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")
 intellij_iml(
-    name = "idea_grandparent_module",
-    compile_lib_deps = [":grandparent_lib"],
-    test_lib_deps = [":grandparent_tests_lib"],
+    name = "iml",
+    compile_lib_deps = [":lib"],
+    test_lib_deps = [":test_lib"],
 )

--- a/scenarios/04_transitive_via_export/parent/BUILD
+++ b/scenarios/04_transitive_via_export/parent/BUILD
@@ -1,16 +1,16 @@
 package(default_visibility = ["//04_transitive_via_export:__subpackages__"])
 
 java_library(
-    name = "parent_lib",
+    name = "lib",
     srcs = glob(["src/main/java/**/*.java"]),
-    deps = ["//04_transitive_via_export/grandparent:grandparent_lib"],
+    deps = ["//04_transitive_via_export/grandparent:lib"],
 )
 
 java_library(
-    name = "parent_tests_lib",
+    name = "test_lib",
     srcs = glob(["src/test/java/**/*.java"]),
     deps=[
-      ":parent_lib",
+      ":lib",
 
       "@org_junit_jupiter_junit_jupiter_api//jar",
       "@org_opentest4j_opentest4j//jar",
@@ -19,15 +19,15 @@ java_library(
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
 junit5_all_in_package_test(
-    name="parent_tests",
+    name="tests",
     java_package="transitive_via_export.parent",
-    runtime_deps=[":parent_tests_lib"]
+    runtime_deps=[":test_lib"]
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")
 intellij_iml(
-    name = "idea_parent_module",
-    compile_lib_deps = [":parent_lib"],
-    compile_module_deps = ["//04_transitive_via_export/grandparent:idea_grandparent_module"],
-    test_lib_deps = [":parent_tests_lib"],
+    name = "iml",
+    compile_lib_deps = [":lib"],
+    compile_module_deps = ["//04_transitive_via_export/grandparent:iml"],
+    test_lib_deps = [":test_lib"],
 )

--- a/scenarios/05_annotation_processor/BUILD
+++ b/scenarios/05_annotation_processor/BUILD
@@ -1,24 +1,25 @@
-package(default_visibility = ["//:__subpackages__"])
+package(default_visibility = ["//05_annotation_processor:__subpackages__"])
 
 load("@rules_intellij_generate//:def.bzl", "intellij_modules_xml")
 intellij_modules_xml(
-    name = "05modules",
+    name = "modules_xml",
     deps = [
-      "//05_annotation_processor/usage:idea_usage_module",
+      "//05_annotation_processor/usage:iml",
     ]
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_compiler_xml")
 intellij_compiler_xml(
-    name = "05processors",
+    name = "compiler_xml",
     iml_target_to_annotation_profile = {
-      "//05_annotation_processor/usage:idea_usage_module" : "foo_profile",
+      "//05_annotation_processor/usage:iml" : "foo_profile",
     }
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_project")
 intellij_project(
-  name="05proj",
-  intellij_modules_xml=":05modules",
-  intellij_compiler_xml=":05processors",
+  name="idea_project",
+  intellij_modules_xml=":modules_xml",
+  intellij_compiler_xml=":compiler_xml",
+  visibility=["//:__subpackages__"],
 )

--- a/scenarios/05_annotation_processor/class_generator/BUILD
+++ b/scenarios/05_annotation_processor/class_generator/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//05_annotation_processor:__subpackages__"])
 
 java_plugin(
-    name = "class_generator_java_plugin",
+    name = "annotation_processor",
     srcs = glob(["src/main/java/**/*.java"]),
     processor_class = "annotation_processor.class_generator.ClassGeneratorAnnotationProcessor",
     resources = glob(["src/main/resources/META-INF/services/javax.annotation.processing.Processor"]),
@@ -10,6 +10,6 @@ java_plugin(
 
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")
 intellij_iml(
-    name = "idea_class_generator_module",
-    compile_lib_deps = [":class_generator_java_plugin"],
+    name = "iml",
+    compile_lib_deps = [":annotation_processor"],
 )

--- a/scenarios/05_annotation_processor/text_file_generator/BUILD
+++ b/scenarios/05_annotation_processor/text_file_generator/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//05_annotation_processor:__subpackages__"])
 
 java_plugin(
-    name = "text_file_generator_java_plugin",
+    name = "annotation_processor",
     srcs = glob(["src/main/java/**/*.java"]),
     processor_class = "annotation_processor.text_file_generator.TextFileGeneratorAnnotationProcessor",
     resources = glob(["src/main/resources/META-INF/services/javax.annotation.processing.Processor"]),
@@ -9,6 +9,6 @@ java_plugin(
 
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")
 intellij_iml(
-    name = "idea_text_file_generator_module",
-    compile_lib_deps = [":text_file_generator_java_plugin"],
+    name = "iml",
+    compile_lib_deps = [":annotation_processor"],
 )

--- a/scenarios/05_annotation_processor/usage/BUILD
+++ b/scenarios/05_annotation_processor/usage/BUILD
@@ -1,19 +1,19 @@
 package(default_visibility = ["//05_annotation_processor:__subpackages__"])
 
 java_library(
-    name = "usage_lib",
+    name = "lib",
     srcs = glob(["src/main/java/**/*.java"]),
     deps = [
-        "//05_annotation_processor/class_generator:class_generator_java_plugin",
-        "//05_annotation_processor/text_file_generator:text_file_generator_java_plugin",
+        "//05_annotation_processor/class_generator:annotation_processor",
+        "//05_annotation_processor/text_file_generator:annotation_processor",
     ],
 )
 
 java_library(
-    name = "usage_tests_lib",
+    name = "test_lib",
     srcs = glob(["src/test/java/**/*.java"]),
     deps=[
-      ":usage_lib",
+      ":lib",
 
       "@org_junit_jupiter_junit_jupiter_api//jar",
       "@org_opentest4j_opentest4j//jar",
@@ -22,18 +22,18 @@ java_library(
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
 junit5_all_in_package_test(
-    name="usage_tests",
+    name="tests",
     java_package="annotation_processor.usage",
-    runtime_deps=[":usage_tests_lib"]
+    runtime_deps=[":test_lib"]
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")
 intellij_iml(
-    name = "idea_usage_module",
-    compile_lib_deps = [":usage_lib"],
-    test_lib_deps = [":usage_tests_lib"],
+    name = "iml",
+    compile_lib_deps = [":lib"],
+    test_lib_deps = [":test_lib"],
     compile_module_deps = [
-        "//05_annotation_processor/class_generator:idea_class_generator_module",
-        "//05_annotation_processor/text_file_generator:idea_text_file_generator_module",
+        "//05_annotation_processor/class_generator:iml",
+        "//05_annotation_processor/text_file_generator:iml",
     ],
 )

--- a/scenarios/06_protobuf_messages/BUILD
+++ b/scenarios/06_protobuf_messages/BUILD
@@ -1,15 +1,16 @@
-package(default_visibility = ["//:__subpackages__"])
+package(default_visibility = ["//06_protobuf_messages:__subpackages__"])
 
 load("@rules_intellij_generate//:def.bzl", "intellij_modules_xml")
 intellij_modules_xml(
-    name = "06modules",
+    name = "modules_xml",
     deps = [
-      "//06_protobuf_messages/usage:idea_usage_module",
+      "//06_protobuf_messages/usage:iml",
     ]
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_project")
 intellij_project(
-  name="06proj",
-  intellij_modules_xml=":06modules",
+  name="idea_project",
+  intellij_modules_xml=":modules_xml",
+  visibility=["//:__subpackages__"],
 )

--- a/scenarios/06_protobuf_messages/README.txt
+++ b/scenarios/06_protobuf_messages/README.txt
@@ -4,4 +4,3 @@ intellij project.
 
 Messages only, no RPC.
 
-Conventions followed, as stated in: https://github.com/cgrushko/proto_library/blob/master/src/BUILD

--- a/scenarios/06_protobuf_messages/html_email/BUILD
+++ b/scenarios/06_protobuf_messages/html_email/BUILD
@@ -1,12 +1,12 @@
 package(default_visibility = ["//:__subpackages__"])
 
-java_proto_library(
-    name = "html_email_java_proto",
-    deps = [":html_email_proto"],
+proto_library(
+    name = "proto",
+    srcs = ["src/main/proto/html_email.proto"],
+    deps = ["//06_protobuf_messages/plain_email:proto"]
 )
 
-proto_library(
-    name = "html_email_proto",
-    srcs = ["src/main/proto/html_email.proto"],
-    deps = ["//06_protobuf_messages/plain_email:plain_email_proto"]
+java_proto_library(
+    name = "proto_java",
+    deps = [":proto"],
 )

--- a/scenarios/06_protobuf_messages/plain_email/BUILD
+++ b/scenarios/06_protobuf_messages/plain_email/BUILD
@@ -1,11 +1,12 @@
 package(default_visibility = ["//:__subpackages__"])
 
-java_proto_library(
-    name = "plain_email_java_proto",
-    deps = [":plain_email_proto"],
-)
-
 proto_library(
-    name = "plain_email_proto",
+    name = "proto",
     srcs = ["src/main/proto/plain_email.proto"],
 )
+
+java_proto_library(
+    name = "proto_java",
+    deps = [":proto"],
+)
+

--- a/scenarios/06_protobuf_messages/usage/BUILD
+++ b/scenarios/06_protobuf_messages/usage/BUILD
@@ -1,21 +1,21 @@
 package(default_visibility = ["//:__subpackages__"])
 
 java_library(
-    name = "usage_lib",
+    name = "lib",
     srcs = glob(["src/main/java/**/*.java"]),
     deps = [
-      "//06_protobuf_messages/plain_email:plain_email_java_proto",
-      "//06_protobuf_messages/html_email:html_email_java_proto",
+      "//06_protobuf_messages/plain_email:proto_java",
+      "//06_protobuf_messages/html_email:proto_java",
     ],
 )
 
 java_library(
-    name = "usage_tests_lib",
+    name = "test_lib",
     srcs = glob(["src/test/java/**/*.java"]),
     deps=[
-      ":usage_lib",
-      "//06_protobuf_messages/plain_email:plain_email_java_proto",
-      "//06_protobuf_messages/html_email:html_email_java_proto",
+      ":lib",
+      "//06_protobuf_messages/plain_email:proto_java",
+      "//06_protobuf_messages/html_email:proto_java",
 
       "@org_junit_jupiter_junit_jupiter_api//jar",
       "@org_opentest4j_opentest4j//jar",
@@ -24,14 +24,14 @@ java_library(
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
 junit5_all_in_package_test(
-    name="usage_tests",
+    name="tests",
     java_package="protobuf_messages.usage",
-    runtime_deps=[":usage_tests_lib"]
+    runtime_deps=[":test_lib"]
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")
 intellij_iml(
-    name = "idea_usage_module",
-    compile_lib_deps = [":usage_lib"],
-    test_lib_deps = [":usage_tests_lib"],
+    name = "iml",
+    compile_lib_deps = [":lib"],
+    test_lib_deps = [":test_lib"],
 )

--- a/scenarios/07_grpc/BUILD
+++ b/scenarios/07_grpc/BUILD
@@ -1,39 +1,39 @@
-package(default_visibility = ["//:__subpackages__"])
+package(default_visibility = ["//07_grpc:__subpackages__"])
+
+proto_library(
+    name = "proto",
+    srcs = ["src/main/proto/fortune.proto"],
+)
+
+java_proto_library(
+    name = "proto_java",
+    deps = [":proto"],
+)
 
 # see https://groups.google.com/forum/#!topic/bazel-discuss/75DSeUTYBxE
 load("@grpc_java//:java_grpc_library.bzl", "java_grpc_library")
 java_grpc_library(
-    name = "fortune_java_grpc",
-    deps = [":fortune_java_proto"],
-    srcs = [":fortune_proto"],
-)
-
-java_proto_library(
-    name = "fortune_java_proto",
-    deps = [":fortune_proto"],
-)
-
-proto_library(
-    name = "fortune_proto",
-    srcs = ["src/main/proto/fortune.proto"],
+    name = "grpc",
+    deps = [":proto_java"],
+    srcs = [":proto"],
 )
 
 java_library(
-    name = "grpc_lib",
+    name = "lib",
     srcs = glob(["src/main/java/**/*.java"]),
     deps = [
-      ":fortune_java_grpc",
-      ":fortune_java_proto",
+      ":grpc",
+      ":proto_java",
       "@grpc_java//stub",
     ],
 )
 
 java_library(
-    name = "grpc_tests_lib",
+    name = "test_lib",
     srcs = glob(["src/test/java/**/*.java"]),
     deps=[
-      ":grpc_lib",
-      ":fortune_java_proto",
+      ":lib",
+      ":proto_java",
       "@grpc_java//stub",
 
       "@org_junit_jupiter_junit_jupiter_api//jar",
@@ -43,28 +43,27 @@ java_library(
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
 junit5_all_in_package_test(
-    name="grpc_tests",
+    name="tests",
     java_package="fortune_grpc",
-    runtime_deps=[":grpc_tests_lib"]
+    runtime_deps=[":test_lib"]
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")
 intellij_iml(
-    name = "idea_fortune_grpc_module",
-    compile_lib_deps = [":grpc_lib"],
-    test_lib_deps = [":grpc_tests_lib"],
+    name = "iml",
+    compile_lib_deps = [":lib"],
+    test_lib_deps = [":test_lib"],
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_modules_xml")
 intellij_modules_xml(
-    name = "07modules",
-    deps = [
-      ":idea_fortune_grpc_module",
-    ]
+    name = "modules_xml",
+    deps = [":iml"]
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_project")
 intellij_project(
-  name="07proj",
-  intellij_modules_xml=":07modules",
+  name="idea_project",
+  intellij_modules_xml=":modules_xml",
+  visibility=["//:__subpackages__"],
 )

--- a/scenarios/BUILD
+++ b/scenarios/BUILD
@@ -2,13 +2,13 @@ load("@rules_intellij_generate//:def.bzl", "intellij_project_group")
 intellij_project_group(
   name="all_scenario_projects",
   intellij_projects=[
-    "//01_one_class:01proj",
-    "//02_one_class_and_one_test:02proj",
-    "//03_basic:03proj",
-    "//04_transitive_via_export:04proj",
-    "//05_annotation_processor:05proj",
-    "//06_protobuf_messages:06proj",
-    "//07_grpc:07proj",
-    "//scenario_tests:scenariotestsproj",
+    "//01_one_class:idea_project",
+    "//02_one_class_and_one_test:idea_project",
+    "//03_basic:idea_project",
+    "//04_transitive_via_export:idea_project",
+    "//05_annotation_processor:idea_project",
+    "//06_protobuf_messages:idea_project",
+    "//07_grpc:idea_project",
+    "//scenario_tests:idea_project",
   ],
 )

--- a/scenarios/scenario_tests/BUILD
+++ b/scenarios/scenario_tests/BUILD
@@ -1,10 +1,10 @@
-package(default_visibility = ["//:__subpackages__"])
+package(default_visibility = ["//scenario_tests:__subpackages__"])
 
 # these tests assert on iml and other build output, and therefore should really
 # have some dependency on those things so that this doesn't execute out of order.
 # but not sure what to do about that at this point.
 java_library(
-    name = "scenario_tests_lib",
+    name = "test_lib",
     srcs = glob(["src/test/java/**/*.java"]),
     deps=[
       "@org_junit_jupiter_junit_jupiter_api//jar",
@@ -14,28 +14,29 @@ java_library(
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
 junit5_all_in_package_test(
-    name="scenario_tests",
+    name="tests",
     java_package="intellij_generate.scenarios",
-    runtime_deps=[":scenario_tests_lib"]
+    runtime_deps=[":test_lib"]
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")
 intellij_iml(
-    name = "idea_root_module",
+    name = "iml",
     sources_roots = [],
     compile_lib_deps = [],
     test_sources_roots = ["src/test/java"],
-    test_lib_deps = [":scenario_tests_lib"],
+    test_lib_deps = [":test_lib"],
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_modules_xml")
 intellij_modules_xml(
-    name = "scenariotestsmodules",
-    deps = [":idea_root_module"]
+    name = "modules_xml",
+    deps = [":iml"]
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_project")
 intellij_project(
-  name="scenariotestsproj",
-  intellij_modules_xml=":scenariotestsmodules",
+  name="idea_project",
+  intellij_modules_xml=":modules_xml",
+  visibility=["//:__subpackages__"]
 )

--- a/scenarios/scenario_tests/src/test/java/intellij_generate/scenarios/S01OneClassTest.java
+++ b/scenarios/scenario_tests/src/test/java/intellij_generate/scenarios/S01OneClassTest.java
@@ -15,7 +15,7 @@ public class S01OneClassTest {
 
   @BeforeAll
   public static void before_all() {
-    imlContent = loadBazelGeneratedFile("01_one_class/idea_root_module.iml");
+    imlContent = loadBazelGeneratedFile("01_one_class/iml.iml");
   }
 
   @Test

--- a/scenarios/scenario_tests/src/test/java/intellij_generate/scenarios/S02OneClassAndOneTest.java
+++ b/scenarios/scenario_tests/src/test/java/intellij_generate/scenarios/S02OneClassAndOneTest.java
@@ -16,7 +16,7 @@ public class S02OneClassAndOneTest {
 
   @BeforeAll
   public static void before_all() {
-    imlContent = loadBazelGeneratedFile("02_one_class_and_one_test/idea_root_module.iml");
+    imlContent = loadBazelGeneratedFile("02_one_class_and_one_test/iml.iml");
   }
 
   @Test

--- a/scenarios/scenario_tests/src/test/java/intellij_generate/scenarios/S03BasicTest.java
+++ b/scenarios/scenario_tests/src/test/java/intellij_generate/scenarios/S03BasicTest.java
@@ -22,13 +22,13 @@ public class S03BasicTest {
 
   @BeforeAll
   public static void before_all() {
-    dolphinImlContent = loadBazelGeneratedFile("03_basic/dolphin/idea_dolphin_module.iml");
-    humanImlContent = loadBazelGeneratedFile("03_basic/human/idea_human_module.iml");
-    gorillaImlContent = loadBazelGeneratedFile("03_basic/gorilla/idea_gorilla_module.iml");
-    primateImlContent = loadBazelGeneratedFile("03_basic/primate/idea_primate_module.iml");
-    mammalImlContent = loadBazelGeneratedFile("03_basic/mammal/idea_mammal_module.iml");
+    dolphinImlContent = loadBazelGeneratedFile("03_basic/dolphin/iml.iml");
+    humanImlContent = loadBazelGeneratedFile("03_basic/human/iml.iml");
+    gorillaImlContent = loadBazelGeneratedFile("03_basic/gorilla/iml.iml");
+    primateImlContent = loadBazelGeneratedFile("03_basic/primate/iml.iml");
+    mammalImlContent = loadBazelGeneratedFile("03_basic/mammal/iml.iml");
 
-    modulesXmlContent = loadBazelGeneratedFile("03_basic/03modules_modules.xml");
+    modulesXmlContent = loadBazelGeneratedFile("03_basic/modules_xml_modules.xml");
   }
 
   @Test

--- a/scenarios/scenario_tests/src/test/java/intellij_generate/scenarios/S04TransitiveWithExportTest.java
+++ b/scenarios/scenario_tests/src/test/java/intellij_generate/scenarios/S04TransitiveWithExportTest.java
@@ -16,9 +16,9 @@ public class S04TransitiveWithExportTest {
 
   @BeforeAll
   public static void before_all() {
-    grandparentImlContent = loadBazelGeneratedFile("04_transitive_via_export/grandparent/idea_grandparent_module.iml");
-    parentImlContent = loadBazelGeneratedFile("04_transitive_via_export/parent/idea_parent_module.iml");
-    childImlContent = loadBazelGeneratedFile("04_transitive_via_export/child/idea_child_module.iml");
+    grandparentImlContent = loadBazelGeneratedFile("04_transitive_via_export/grandparent/iml.iml");
+    parentImlContent = loadBazelGeneratedFile("04_transitive_via_export/parent/iml.iml");
+    childImlContent = loadBazelGeneratedFile("04_transitive_via_export/child/iml.iml");
   }
 
   @Test

--- a/scenarios/scenario_tests/src/test/java/intellij_generate/scenarios/S05AnnotationProcessorTest.java
+++ b/scenarios/scenario_tests/src/test/java/intellij_generate/scenarios/S05AnnotationProcessorTest.java
@@ -13,7 +13,7 @@ public class S05AnnotationProcessorTest {
 
   @BeforeAll
   public static void before_all() {
-    compilerXmlContent = loadBazelGeneratedFile("05_annotation_processor/05processors_compiler.xml");
+    compilerXmlContent = loadBazelGeneratedFile("05_annotation_processor/compiler_xml_compiler.xml");
   }
 
   @Test
@@ -23,7 +23,7 @@ public class S05AnnotationProcessorTest {
       xpathList(compilerXmlContent, "/project/component/annotationProcessing/profile/@name"));
 
     assertEquals(
-      asList("idea_usage_module"),
+      asList("iml"),
       xpathList(compilerXmlContent, "/project/component/annotationProcessing/profile[@name='foo_profile']/module/@name"));
 
     assertEquals(

--- a/scenarios/scenario_tests/src/test/java/intellij_generate/scenarios/S06ProtobufMessagesTest.java
+++ b/scenarios/scenario_tests/src/test/java/intellij_generate/scenarios/S06ProtobufMessagesTest.java
@@ -14,7 +14,7 @@ public class S06ProtobufMessagesTest {
 
   @BeforeAll
   public static void before_all() {
-    usageImlContent = loadBazelGeneratedFile("06_protobuf_messages/usage/idea_usage_module.iml");
+    usageImlContent = loadBazelGeneratedFile("06_protobuf_messages/usage/iml.iml");
   }
 
   @Test
@@ -22,9 +22,9 @@ public class S06ProtobufMessagesTest {
     // use of bazel java proto tasks should result in inclusion of the google protobuf library,
     // as well as jars containing the compiled code-gen'd classes based on the specified proto definitions.
     assertEquals(asList(
-      "bazel-out/darwin_x86_64-fastbuild/bin/06_protobuf_messages/plain_email/libplain_email_proto-speed.jar!/",
+      "bazel-out/darwin_x86_64-fastbuild/bin/06_protobuf_messages/plain_email/libproto-speed.jar!/",
       "bazel-out/darwin_x86_64-fastbuild/bin/external/com_google_protobuf_java/libprotobuf_java.jar!/",
-      "bazel-out/darwin_x86_64-fastbuild/bin/06_protobuf_messages/html_email/libhtml_email_proto-speed.jar!/"),
+      "bazel-out/darwin_x86_64-fastbuild/bin/06_protobuf_messages/html_email/libproto-speed.jar!/"),
       removeWorkingDirectory(
         xpathList(usageImlContent, "/module/component/orderEntry[@type='module-library' and not(@scope)]/library/CLASSES/root/@url")));
 

--- a/scenarios/scenario_tests/src/test/java/intellij_generate/scenarios/S07GrpcTest.java
+++ b/scenarios/scenario_tests/src/test/java/intellij_generate/scenarios/S07GrpcTest.java
@@ -14,16 +14,16 @@ public class S07GrpcTest {
 
   @BeforeAll
   public static void before_all() {
-    fortuneGrpcImlContent = loadBazelGeneratedFile("07_grpc/idea_fortune_grpc_module.iml");
+    fortuneGrpcImlContent = loadBazelGeneratedFile("07_grpc/iml.iml");
   }
 
   @Test
   public void libraries() {
     // might be going overboard, making a really brittle test. we'll see.
     assertEquals(asList(
-      "bazel-out/darwin_x86_64-fastbuild/bin/07_grpc/libfortune_java_grpc.jar!/",
+      "bazel-out/darwin_x86_64-fastbuild/bin/07_grpc/libgrpc.jar!/",
       "external/com_google_code_findbugs_jsr305/jar/jsr305-3.0.0.jar!/",
-      "bazel-out/darwin_x86_64-fastbuild/bin/07_grpc/libfortune_proto-speed.jar!/",
+      "bazel-out/darwin_x86_64-fastbuild/bin/07_grpc/libproto-speed.jar!/",
       "bazel-out/darwin_x86_64-fastbuild/bin/external/com_google_protobuf_java/libprotobuf_java.jar!/",
       "bazel-out/darwin_x86_64-fastbuild/bin/external/grpc_java/core/libcore.jar!/",
       "bazel-out/darwin_x86_64-fastbuild/bin/external/grpc_java/context/libcontext.jar!/",


### PR DESCRIPTION
the old bazel target labels were over-specified. create new, terser conventions.
cross-cutting naming reform, system is in README