### PR TITLE
Redo of how java sources, java_library, and intellij_iml relate, nota…

### DIFF
--- a/rules/def.bzl
+++ b/rules/def.bzl
@@ -1,4 +1,11 @@
 load("@rules_intellij_generate//private:intellij_iml.bzl", "intellij_iml")
+load("@rules_intellij_generate//private:intellij_source.bzl",
+    "intellij_source_java_library",
+    "intellij_source_java_plugin",
+    "intellij_source",
+    "MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP",
+    "MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP",
+    "MAVEN_STANDARD_RESOURCE_FOLDER")
 load("@rules_intellij_generate//private:intellij_modules_xml.bzl", "intellij_modules_xml")
 load("@rules_intellij_generate//private:intellij_compiler_xml.bzl", "intellij_compiler_xml")
 load("@rules_intellij_generate//private:intellij_project.bzl", "intellij_project")

--- a/rules/private/BUILD
+++ b/rules/private/BUILD
@@ -27,26 +27,31 @@ java_binary(
 
 # === PRIVATE ===
 
-java_library(
-    name = "lib",
-    srcs = glob(["src/main/java/**/*.java"]),
+# use the rules developed in this project to also
+# generate intellij files for the project.
+
+load(":intellij_source.bzl",
+    "intellij_source_java_library",
+    "MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP",
+    "MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP")
+
+intellij_source_java_library(
+    name="lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP,
     deps = [
         "@com_beust_jcommander//jar",
     ]
 )
 
-# TODO: some bazel+ junit5 magic can probably be done to make the tests run
-# automatically (without explicitly specifying a package), or from a directory or something.
+intellij_source_java_library(
+    name="test_lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP,
+    deps=[
+      ":lib",
 
-java_library(
-  name="test_lib",
-  srcs = glob(["src/test/java/**/*.java"]),
-  deps=[
-    ":lib",
-
-    "@org_junit_jupiter_junit_jupiter_api//jar",
-    "@org_opentest4j_opentest4j//jar",
-  ],
+      "@org_junit_jupiter_junit_jupiter_api//jar",
+      "@org_opentest4j_opentest4j//jar",
+    ],
 )
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
@@ -64,14 +69,11 @@ exports_files([
     "install_intellij_iml.sh.template",
 ])
 
-# use the rules developed in this project to also
-# generate intellij files for the project.
-
 load(":intellij_iml.bzl", "intellij_iml")
 intellij_iml(
-    name = "iml",
-    compile_lib_deps = [":lib"],
-    test_lib_deps = [":test_lib"],
+    name="iml",
+    java_source=":lib",
+    test_java_source=":test_lib",
 )
 
 load(":intellij_modules_xml.bzl", "intellij_modules_xml")

--- a/rules/private/common.bzl
+++ b/rules/private/common.bzl
@@ -34,3 +34,36 @@ def dot_idea_project_dir_relative_to_workspace_root(ctx):
 
 def build_dirname(ctx):
     return ctx.build_file_path.rstrip("/BUILD").split("/")[-1]
+
+transitive_iml_provider = provider(
+    doc = "TODO",
+    fields = {
+        "transitive_imls": "TODO",
+    }
+)
+
+# see https://bazel.build/designs/skylark/declared-providers.html
+iml_info_provider = provider(
+  doc = """The struct returned as the result of intellij_iml execution.
+           Primarily allows "child" modules to get information about
+           their "parent" modules, such as what the full set of immediate
+           and transitive iml module parents is, and the libs those parents
+           depend on.
+        """,
+  fields = {
+    "iml_module_name": "This iml module's name.",
+    "transitive_iml_module_names": "Names of all parent iml modules, of this iml module.",
+
+    "iml_path_relative_to_workspace_root": "Path to where the iml file gets symlinked, relative to the workspace root.",
+    "transitive_iml_paths_relative_to_workspace_root": "Paths to where the iml file gets symlinked, relative to the workspace root, for all parent iml's.",
+
+    "transitive_imls": "TODO",
+  })
+
+intellij_java_source_info_provider = provider(
+  doc = """TODO""",
+  fields = {
+    "source_folders": "TODO",
+    "java_dep": "TODO",
+    "transitive_intellij_java_sources": "TODO"
+  })

--- a/rules/private/intellij_compiler_xml.bzl
+++ b/rules/private/intellij_compiler_xml.bzl
@@ -1,5 +1,6 @@
 load(":common.bzl", "GENERATED_SOURCES_SUBDIR", "GENERATED_TEST_SOURCES_SUBDIR", "install_script_provider")
 load(":intellij_iml.bzl", "iml_info_provider") # see https://bazel.build/designs/skylark/declared-providers.html
+load(":common.bzl", "transitive_iml_provider")
 
 def _impl(ctx):
     """Based on ctx.attr inputs, invoke the compiler.xml-generating executable,
@@ -17,8 +18,9 @@ def _impl(ctx):
         # (which come from dependencies on java_plugin's),
         # collect these up.
         all_annotation_processors = depset()
-        for compile_lib_dep in (dep[iml_info_provider].compile_lib_deps): # TODO: include transitive module compile libs?
-            all_annotation_processors += compile_lib_dep.java.annotation_processing.processor_classnames
+        all_annotation_processors += dep.java.annotation_processing.processor_classnames
+        for tdep in dep[transitive_iml_provider].transitive_imls:
+            all_annotation_processors += tdep.java.annotation_processing.processor_classnames
 
         for annotation_processor in all_annotation_processors:
             args.append("--module-to-annotation-processor-mapping")

--- a/rules/private/intellij_modules_xml.bzl
+++ b/rules/private/intellij_modules_xml.bzl
@@ -6,10 +6,15 @@ def _impl(ctx):
     """Based on ctx.attr inputs, invoke the modules.xml-generating executable,
        and write the result to the designated modules.xml path."""
 
-    iml_paths_relative_to_workspace_root = []
+    all_iml_paths_relative_to_workspace_root = []
     for dep in ctx.attr.deps:
-        iml_paths_relative_to_workspace_root.append(dep[iml_info_provider].iml_path_relative_to_workspace_root)
-        iml_paths_relative_to_workspace_root.extend(dep[iml_info_provider].transitive_iml_paths_relative_to_workspace_root)
+        all_iml_paths_relative_to_workspace_root.append(dep[iml_info_provider].iml_path_relative_to_workspace_root)
+        all_iml_paths_relative_to_workspace_root.extend(dep[iml_info_provider].transitive_iml_paths_relative_to_workspace_root)
+
+    iml_paths_relative_to_workspace_root = []
+    for iml_path in all_iml_paths_relative_to_workspace_root:
+        if iml_path not in iml_paths_relative_to_workspace_root:
+            iml_paths_relative_to_workspace_root.append(iml_path)
 
     idea_project_dir = dir_relative_to_workspace_root(ctx)
     iml_path_args = []

--- a/rules/private/intellij_source.bzl
+++ b/rules/private/intellij_source.bzl
@@ -1,0 +1,114 @@
+load(":common.bzl", "iml_info_provider", "transitive_iml_provider", "intellij_java_source_info_provider")
+
+def _impl(ctx):
+    """TODO"""
+
+    transitive_imls = []
+    for dep in ctx.attr.deps:
+        if iml_info_provider in dep:
+            transitive_imls.append(dep)
+        if transitive_iml_provider in dep:
+            transitive_imls += dep[transitive_iml_provider].transitive_imls
+
+    transitive_intellij_java_sources = []
+    for dep in ctx.attr.deps:
+        if intellij_java_source_info_provider in dep:
+            transitive_intellij_java_sources += [dep]
+            transitive_intellij_java_sources += dep[intellij_java_source_info_provider].transitive_intellij_java_sources
+
+    # TODO: convert intellij_iml to use JavaInfo instead of the (old) .java
+    # This struct makes this rule usable anywhere any java rule can go,
+    # e.g. in a list of java_library deps
+    return struct(
+        providers=[
+          ctx.attr.java_dep[JavaInfo],
+          intellij_java_source_info_provider(
+            source_folders=ctx.attr.source_folders,
+            java_dep=ctx.attr.java_dep,
+            transitive_intellij_java_sources=transitive_intellij_java_sources,
+          ),
+          transitive_iml_provider(
+              transitive_imls=transitive_imls,
+          )
+        ],
+        java=ctx.attr.java_dep.java
+    )
+
+_intellij_java_source = rule(
+    doc="""TODO""",
+    implementation=_impl,
+
+    attrs={
+        "source_folders": attr.string_list(doc=""),
+        "java_dep": attr.label(doc=""),
+        "deps": attr.label_list(doc=""),
+    },
+)
+
+def glob_from_intellij_source_folder_to_wildcard_map(source_folder_map):
+    globs = []
+    for source_folder in source_folder_map.keys():
+        glob_wildcard = source_folder_map[source_folder]
+        globs.append(source_folder + "/" + glob_wildcard)
+    return native.glob(globs)
+
+def intellij_source_java_library(
+    name=None,
+    source_folder_to_wildcard_map={},
+    deps=[],
+    exports=[]):
+
+    private_java_library_name = "_" + name
+    native.java_library(
+        name = private_java_library_name,
+        srcs = glob_from_intellij_source_folder_to_wildcard_map(source_folder_to_wildcard_map),
+        deps=deps,
+        exports=exports,
+    )
+    _intellij_java_source(
+        name=name,
+        source_folders=source_folder_to_wildcard_map.keys(),
+        java_dep=":" + private_java_library_name,
+        deps=deps,
+    )
+
+def intellij_source(
+    name=None,
+    deps=[]):
+
+    _intellij_java_source(
+        name=name,
+        deps=deps,
+    )
+
+# TODO: factor out duplication in a sensible way when we have like 3 of these
+def intellij_source_java_plugin(
+    name=None,
+    source_folder_to_wildcard_map={},
+    deps=[],
+    resource_folder_to_wildcard_map={},
+    processor_class=None,
+    generates_api=0):
+
+    private_java_library_name = "_" + name
+    native.java_plugin(
+        name = private_java_library_name,
+        srcs = glob_from_intellij_source_folder_to_wildcard_map(source_folder_to_wildcard_map),
+        resources = glob_from_intellij_source_folder_to_wildcard_map(resource_folder_to_wildcard_map),
+        processor_class=processor_class,
+        generates_api=generates_api,
+        deps=deps,
+    )
+    #TODO: resources
+    _intellij_java_source(
+        name=name,
+        source_folders=source_folder_to_wildcard_map.keys(),
+        java_dep=":" + private_java_library_name,
+        deps=deps,
+    )
+
+MAVEN_STANDARD_RESOURCE_FOLDER="src/main/resources"
+
+MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP={"src/main/java":"**/*.java"}
+MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP={"src/test/java":"**/*.java"}
+

--- a/scenarios/01_one_class/BUILD
+++ b/scenarios/01_one_class/BUILD
@@ -1,23 +1,24 @@
 package(default_visibility = ["//01_one_class:__subpackages__"])
 
-java_library(
-    name = "lib",
-    srcs = glob(["src/**/*.java"]),
-)
-
+# TODO: explicitly spcify run targets on the iml by way of something
+# like run_targets = [java bin...]
+# or even, a dict of target name to java_bin
 java_binary(
     name = "run_A",
     main_class="oneclass.A",
     srcs = glob(["src/**/*.java"]),
 )
 
+load("@rules_intellij_generate//:def.bzl", "intellij_source_java_library")
+intellij_source_java_library(
+    name="lib",
+    source_folder_to_wildcard_map={"src": "**/*.java"},
+)
+
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")
 intellij_iml(
-    name = "iml",
-    sources_roots = ["src"],
-    compile_lib_deps = [":lib"],
-    test_sources_roots = [],
-    test_lib_deps = [],
+    name="iml",
+    java_source=":lib",
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_modules_xml")
@@ -28,7 +29,7 @@ intellij_modules_xml(
 
 load("@rules_intellij_generate//:def.bzl", "intellij_project")
 intellij_project(
-  name="idea_project",
-  intellij_modules_xml=":modules_xml",
-  visibility=["//:__subpackages__"],
+    name="idea_project",
+    intellij_modules_xml=":modules_xml",
+    visibility=["//:__subpackages__"],
 )

--- a/scenarios/02_one_class_and_one_test/BUILD
+++ b/scenarios/02_one_class_and_one_test/BUILD
@@ -1,13 +1,15 @@
 package(default_visibility = ["//02_one_class_and_one_test:__subpackages__"])
 
-java_library(
-    name = "lib",
-    srcs = glob(["src/**/*.java"]),
+load("@rules_intellij_generate//:def.bzl", "intellij_source_java_library")
+
+intellij_source_java_library(
+    name="lib",
+    source_folder_to_wildcard_map={"src": "**/*.java"},
 )
 
-java_library(
-    name = "test_lib",
-    srcs = glob(["test/**/*.java"]),
+intellij_source_java_library(
+    name="test_lib",
+    source_folder_to_wildcard_map={"test": "**/*.java"},
     deps=[
       ":lib",
 
@@ -16,20 +18,11 @@ java_library(
     ],
 )
 
-load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
-junit5_all_in_package_test(
-    name="tests",
-    java_package="one_class_and_one_test",
-    runtime_deps=[":test_lib"]
-)
-
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")
 intellij_iml(
-    name = "iml",
-    sources_roots = ["src"],
-    compile_lib_deps = [":lib"],
-    test_sources_roots = ["test"],
-    test_lib_deps = [":test_lib"],
+    name="iml",
+    java_source=":lib",
+    test_java_source=":test_lib",
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_modules_xml")
@@ -43,4 +36,11 @@ intellij_project(
   name="idea_project",
   intellij_modules_xml=":modules_xml",
   visibility=["//:__subpackages__"],
+)
+
+load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
+junit5_all_in_package_test(
+    name="tests",
+    java_package="one_class_and_one_test",
+    runtime_deps=[":test_lib"]
 )

--- a/scenarios/03_basic/dolphin/BUILD
+++ b/scenarios/03_basic/dolphin/BUILD
@@ -1,23 +1,35 @@
 package(default_visibility = ["//03_basic:__subpackages__"])
 
-java_library(
-    name = "lib",
-    srcs = glob(["src/main/java/**/*.java"]),
+load("@rules_intellij_generate//:def.bzl",
+    "intellij_source_java_library",
+    "MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP",
+    "MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP")
+
+intellij_source_java_library(
+    name="lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP,
     deps=[
-      "//03_basic/mammal:lib",
+        "//03_basic/mammal:iml",
     ]
 )
 
-java_library(
-    name = "test_lib",
-    srcs = glob(["src/test/java/**/*.java"]),
+intellij_source_java_library(
+    name="test_lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP,
     deps=[
-      ":lib",
-      "//03_basic/mammal:lib",
+        ":lib",
+        "//03_basic/mammal:iml",
 
-      "@org_junit_jupiter_junit_jupiter_api//jar",
-      "@org_opentest4j_opentest4j//jar",
+        "@org_junit_jupiter_junit_jupiter_api//jar",
+        "@org_opentest4j_opentest4j//jar",
     ],
+)
+
+load("@rules_intellij_generate//:def.bzl", "intellij_iml")
+intellij_iml(
+    name = "iml",
+    java_source=":lib",
+    test_java_source=":test_lib",
 )
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
@@ -25,12 +37,4 @@ junit5_all_in_package_test(
     name="tests",
     java_package="basic.dolphin",
     runtime_deps=[":test_lib"]
-)
-
-load("@rules_intellij_generate//:def.bzl", "intellij_iml")
-intellij_iml(
-    name = "iml",
-    compile_lib_deps = [":lib"],
-    compile_module_deps = ["//03_basic/mammal:iml"],
-    test_lib_deps = [":test_lib"],
 )

--- a/scenarios/03_basic/gorilla/BUILD
+++ b/scenarios/03_basic/gorilla/BUILD
@@ -1,24 +1,36 @@
 package(default_visibility = ["//03_basic:__subpackages__"])
 
-java_library(
-    name = "lib",
-    srcs = glob(["src/main/java/**/*.java"]),
+load("@rules_intellij_generate//:def.bzl",
+    "intellij_source_java_library",
+    "MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP",
+    "MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP")
+
+intellij_source_java_library(
+    name="lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP,
     deps=[
-      "//03_basic/primate:lib",
+        "//03_basic/primate:iml",
     ]
 )
 
-java_library(
-    name = "test_lib",
-    srcs = glob(["src/test/java/**/*.java"]),
+intellij_source_java_library(
+    name="test_lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP,
     deps=[
-      "lib",
-      "//03_basic/primate:lib",
-      "//03_basic/mammal:lib",
+        ":lib",
+        "//03_basic/primate:iml",
+        "//03_basic/mammal:iml",
 
-      "@org_junit_jupiter_junit_jupiter_api//jar",
-      "@org_opentest4j_opentest4j//jar",
+        "@org_junit_jupiter_junit_jupiter_api//jar",
+        "@org_opentest4j_opentest4j//jar",
     ],
+)
+
+load("@rules_intellij_generate//:def.bzl", "intellij_iml")
+intellij_iml(
+    name = "iml",
+    java_source=":lib",
+    test_java_source=":test_lib",
 )
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
@@ -26,12 +38,4 @@ junit5_all_in_package_test(
     name="tests",
     java_package="basic.gorilla",
     runtime_deps=[":test_lib"]
-)
-
-load("@rules_intellij_generate//:def.bzl", "intellij_iml")
-intellij_iml(
-    name = "iml",
-    compile_lib_deps = [":lib"],
-    compile_module_deps = ["//03_basic/primate:iml"],
-    test_lib_deps = [":test_lib"],
 )

--- a/scenarios/03_basic/human/BUILD
+++ b/scenarios/03_basic/human/BUILD
@@ -1,24 +1,36 @@
 package(default_visibility = ["//03_basic:__subpackages__"])
 
-java_library(
-    name = "lib",
-    srcs = glob(["src/main/java/**/*.java"]),
+load("@rules_intellij_generate//:def.bzl",
+    "intellij_source_java_library",
+    "MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP",
+    "MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP")
+
+intellij_source_java_library(
+    name="lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP,
     deps=[
-      "//03_basic/primate:lib",
+        "//03_basic/primate:iml",
     ]
 )
 
-java_library(
-    name = "test_lib",
-    srcs = glob(["src/test/java/**/*.java"]),
+intellij_source_java_library(
+    name="test_lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP,
     deps=[
-      ":lib",
-      "//03_basic/primate:lib",
-      "//03_basic/mammal:lib",
+        ":lib",
+        "//03_basic/primate:iml",
+        "//03_basic/mammal:iml",
 
-      "@org_junit_jupiter_junit_jupiter_api//jar",
-      "@org_opentest4j_opentest4j//jar",
+        "@org_junit_jupiter_junit_jupiter_api//jar",
+        "@org_opentest4j_opentest4j//jar",
     ],
+)
+
+load("@rules_intellij_generate//:def.bzl", "intellij_iml")
+intellij_iml(
+    name = "iml",
+    java_source=":lib",
+    test_java_source=":test_lib",
 )
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
@@ -26,14 +38,4 @@ junit5_all_in_package_test(
     name="tests",
     java_package="basic.human",
     runtime_deps=[":test_lib"]
-)
-
-load("@rules_intellij_generate//:def.bzl", "intellij_iml")
-intellij_iml(
-    name = "iml",
-    compile_lib_deps = [":lib"],
-    compile_module_deps = [
-      "//03_basic/primate:iml"
-    ],
-    test_lib_deps = [":test_lib"],
 )

--- a/scenarios/03_basic/mammal/BUILD
+++ b/scenarios/03_basic/mammal/BUILD
@@ -1,19 +1,31 @@
 package(default_visibility = ["//03_basic:__subpackages__"])
 
-java_library(
-    name = "lib",
-    srcs = glob(["src/main/java/**/*.java"]),
+load("@rules_intellij_generate//:def.bzl",
+    "intellij_source_java_library",
+    "MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP",
+    "MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP")
+
+intellij_source_java_library(
+    name="lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP,
 )
 
-java_library(
-    name = "test_lib",
-    srcs = glob(["src/test/java/**/*.java"]),
+intellij_source_java_library(
+    name="test_lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP,
     deps=[
-      ":lib",
+        ":lib",
 
-      "@org_junit_jupiter_junit_jupiter_api//jar",
-      "@org_opentest4j_opentest4j//jar",
+        "@org_junit_jupiter_junit_jupiter_api//jar",
+        "@org_opentest4j_opentest4j//jar",
     ],
+)
+
+load("@rules_intellij_generate//:def.bzl", "intellij_iml")
+intellij_iml(
+    name = "iml",
+    java_source=":lib",
+    test_java_source=":test_lib",
 )
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
@@ -21,11 +33,4 @@ junit5_all_in_package_test(
     name="tests",
     java_package="basic.mammal",
     runtime_deps=[":lib"]
-)
-
-load("@rules_intellij_generate//:def.bzl", "intellij_iml")
-intellij_iml(
-    name = "iml",
-    compile_lib_deps = [":lib"],
-    test_lib_deps = [":test_lib"],
 )

--- a/scenarios/03_basic/primate/BUILD
+++ b/scenarios/03_basic/primate/BUILD
@@ -1,23 +1,35 @@
 package(default_visibility = ["//03_basic:__subpackages__"])
 
-java_library(
-    name = "lib",
-    srcs = glob(["src/main/java/**/*.java"]),
+load("@rules_intellij_generate//:def.bzl",
+    "intellij_source_java_library",
+    "MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP",
+    "MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP")
+
+intellij_source_java_library(
+    name="lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP,
     deps=[
-      "//03_basic/mammal:lib",
+        "//03_basic/mammal:iml",
     ]
 )
 
-java_library(
-    name = "test_lib",
-    srcs = glob(["src/test/java/**/*.java"]),
+intellij_source_java_library(
+    name="test_lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP,
     deps=[
-      ":lib",
-      "//03_basic/mammal:lib",
+        ":lib",
+        "//03_basic/mammal:iml",
 
-      "@org_junit_jupiter_junit_jupiter_api//jar",
-      "@org_opentest4j_opentest4j//jar",
+        "@org_junit_jupiter_junit_jupiter_api//jar",
+        "@org_opentest4j_opentest4j//jar",
     ],
+)
+
+load("@rules_intellij_generate//:def.bzl", "intellij_iml")
+intellij_iml(
+    name = "iml",
+    java_source=":lib",
+    test_java_source=":test_lib",
 )
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
@@ -25,12 +37,4 @@ junit5_all_in_package_test(
     name="tests",
     java_package="basic.primate",
     runtime_deps=[":test_lib"]
-)
-
-load("@rules_intellij_generate//:def.bzl", "intellij_iml")
-intellij_iml(
-    name = "iml",
-    compile_lib_deps = [":lib"],
-    compile_module_deps = ["//03_basic/mammal:iml"],
-    test_lib_deps = [":lib"],
 )

--- a/scenarios/04_transitive_via_export/child/BUILD
+++ b/scenarios/04_transitive_via_export/child/BUILD
@@ -1,20 +1,34 @@
 package(default_visibility = ["//04_transitive_via_export:__subpackages__"])
 
-java_library(
-    name = "lib",
-    srcs = glob(["src/main/java/**/*.java"]),
-    deps = ["//04_transitive_via_export/parent:lib"],
+load("@rules_intellij_generate//:def.bzl",
+    "intellij_source_java_library",
+    "MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP",
+    "MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP")
+
+intellij_source_java_library(
+    name="lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP,
+    deps=[
+        "//04_transitive_via_export/parent:iml",
+    ]
 )
 
-java_library(
-    name = "test_lib",
-    srcs = glob(["src/test/java/**/*.java"]),
+intellij_source_java_library(
+    name="test_lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP,
     deps=[
-      ":lib",
+        ":lib",
 
-      "@org_junit_jupiter_junit_jupiter_api//jar",
-      "@org_opentest4j_opentest4j//jar",
+        "@org_junit_jupiter_junit_jupiter_api//jar",
+        "@org_opentest4j_opentest4j//jar",
     ],
+)
+
+load("@rules_intellij_generate//:def.bzl", "intellij_iml")
+intellij_iml(
+    name = "iml",
+    java_source=":lib",
+    test_java_source=":test_lib",
 )
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
@@ -22,12 +36,4 @@ junit5_all_in_package_test(
     name="tests",
     java_package="transitive_via_export.child",
     runtime_deps=[":test_lib"]
-)
-
-load("@rules_intellij_generate//:def.bzl", "intellij_iml")
-intellij_iml(
-    name = "iml",
-    compile_lib_deps = [":lib"],
-    compile_module_deps = ["//04_transitive_via_export/parent:iml"],
-    test_lib_deps = [":test_lib"],
 )

--- a/scenarios/04_transitive_via_export/grandparent/BUILD
+++ b/scenarios/04_transitive_via_export/grandparent/BUILD
@@ -1,21 +1,37 @@
 package(default_visibility = ["//04_transitive_via_export:__subpackages__"])
 
-java_library(
-    name = "lib",
-    srcs = glob(["src/main/java/**/*.java"]),
-    deps = ["@com_google_guava_guava//jar"],
-    exports = ["@com_google_guava_guava//jar"],
+load("@rules_intellij_generate//:def.bzl",
+    "intellij_source_java_library",
+    "MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP",
+    "MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP")
+
+intellij_source_java_library(
+    name="lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP,
+    deps=[
+        "@com_google_guava_guava//jar",
+    ],
+    exports = [
+        "@com_google_guava_guava//jar"
+    ],
 )
 
-java_library(
-    name = "test_lib",
-    srcs = glob(["src/test/java/**/*.java"]),
+intellij_source_java_library(
+    name="test_lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP,
     deps=[
-      ":lib",
+        ":lib",
 
-      "@org_junit_jupiter_junit_jupiter_api//jar",
-      "@org_opentest4j_opentest4j//jar",
+        "@org_junit_jupiter_junit_jupiter_api//jar",
+        "@org_opentest4j_opentest4j//jar",
     ],
+)
+
+load("@rules_intellij_generate//:def.bzl", "intellij_iml")
+intellij_iml(
+    name = "iml",
+    java_source=":lib",
+    test_java_source=":test_lib",
 )
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
@@ -23,11 +39,4 @@ junit5_all_in_package_test(
     name="tests",
     java_package="transitive_via_export.grandparent",
     runtime_deps=[":test_lib"]
-)
-
-load("@rules_intellij_generate//:def.bzl", "intellij_iml")
-intellij_iml(
-    name = "iml",
-    compile_lib_deps = [":lib"],
-    test_lib_deps = [":test_lib"],
 )

--- a/scenarios/04_transitive_via_export/parent/BUILD
+++ b/scenarios/04_transitive_via_export/parent/BUILD
@@ -1,20 +1,34 @@
 package(default_visibility = ["//04_transitive_via_export:__subpackages__"])
 
-java_library(
-    name = "lib",
-    srcs = glob(["src/main/java/**/*.java"]),
-    deps = ["//04_transitive_via_export/grandparent:lib"],
+load("@rules_intellij_generate//:def.bzl",
+    "intellij_source_java_library",
+    "MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP",
+    "MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP")
+
+intellij_source_java_library(
+    name="lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP,
+    deps=[
+        "//04_transitive_via_export/grandparent:iml"
+    ]
 )
 
-java_library(
-    name = "test_lib",
-    srcs = glob(["src/test/java/**/*.java"]),
+intellij_source_java_library(
+    name="test_lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP,
     deps=[
-      ":lib",
+        ":lib",
 
-      "@org_junit_jupiter_junit_jupiter_api//jar",
-      "@org_opentest4j_opentest4j//jar",
+        "@org_junit_jupiter_junit_jupiter_api//jar",
+        "@org_opentest4j_opentest4j//jar",
     ],
+)
+
+load("@rules_intellij_generate//:def.bzl", "intellij_iml")
+intellij_iml(
+    name = "iml",
+    java_source=":lib",
+    test_java_source=":test_lib",
 )
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
@@ -22,12 +36,4 @@ junit5_all_in_package_test(
     name="tests",
     java_package="transitive_via_export.parent",
     runtime_deps=[":test_lib"]
-)
-
-load("@rules_intellij_generate//:def.bzl", "intellij_iml")
-intellij_iml(
-    name = "iml",
-    compile_lib_deps = [":lib"],
-    compile_module_deps = ["//04_transitive_via_export/grandparent:iml"],
-    test_lib_deps = [":test_lib"],
 )

--- a/scenarios/05_annotation_processor/class_generator/BUILD
+++ b/scenarios/05_annotation_processor/class_generator/BUILD
@@ -1,15 +1,20 @@
 package(default_visibility = ["//05_annotation_processor:__subpackages__"])
 
-java_plugin(
-    name = "annotation_processor",
-    srcs = glob(["src/main/java/**/*.java"]),
+load("@rules_intellij_generate//:def.bzl",
+    "intellij_source_java_plugin",
+    "MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP",
+    "MAVEN_STANDARD_RESOURCE_FOLDER")
+
+intellij_source_java_plugin(
+    name="annotation_processor",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP,
     processor_class = "annotation_processor.class_generator.ClassGeneratorAnnotationProcessor",
-    resources = glob(["src/main/resources/META-INF/services/javax.annotation.processing.Processor"]),
+    resource_folder_to_wildcard_map = {MAVEN_STANDARD_RESOURCE_FOLDER: "META-INF/services/javax.annotation.processing.Processor"},
     generates_api = 1, # must be specified or dependent targets will not see gen'd classfiles
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")
 intellij_iml(
     name = "iml",
-    compile_lib_deps = [":annotation_processor"],
+    java_source=":annotation_processor",
 )

--- a/scenarios/05_annotation_processor/text_file_generator/BUILD
+++ b/scenarios/05_annotation_processor/text_file_generator/BUILD
@@ -1,14 +1,19 @@
 package(default_visibility = ["//05_annotation_processor:__subpackages__"])
 
-java_plugin(
-    name = "annotation_processor",
-    srcs = glob(["src/main/java/**/*.java"]),
+load("@rules_intellij_generate//:def.bzl",
+    "intellij_source_java_plugin",
+    "MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP",
+    "MAVEN_STANDARD_RESOURCE_FOLDER")
+
+intellij_source_java_plugin(
+    name="annotation_processor",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP,
     processor_class = "annotation_processor.text_file_generator.TextFileGeneratorAnnotationProcessor",
-    resources = glob(["src/main/resources/META-INF/services/javax.annotation.processing.Processor"]),
+    resource_folder_to_wildcard_map = {MAVEN_STANDARD_RESOURCE_FOLDER: "META-INF/services/javax.annotation.processing.Processor"},
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")
 intellij_iml(
     name = "iml",
-    compile_lib_deps = [":annotation_processor"],
+    java_source=":annotation_processor",
 )

--- a/scenarios/05_annotation_processor/usage/BUILD
+++ b/scenarios/05_annotation_processor/usage/BUILD
@@ -1,23 +1,35 @@
 package(default_visibility = ["//05_annotation_processor:__subpackages__"])
 
-java_library(
-    name = "lib",
-    srcs = glob(["src/main/java/**/*.java"]),
-    deps = [
-        "//05_annotation_processor/class_generator:annotation_processor",
-        "//05_annotation_processor/text_file_generator:annotation_processor",
+load("@rules_intellij_generate//:def.bzl",
+    "intellij_source_java_library",
+    "MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP",
+    "MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP")
+
+intellij_source_java_library(
+    name="lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP,
+    deps=[
+        "//05_annotation_processor/class_generator:iml",
+        "//05_annotation_processor/text_file_generator:iml",
+    ]
+)
+
+intellij_source_java_library(
+    name="test_lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP,
+    deps=[
+        ":lib",
+
+        "@org_junit_jupiter_junit_jupiter_api//jar",
+        "@org_opentest4j_opentest4j//jar",
     ],
 )
 
-java_library(
-    name = "test_lib",
-    srcs = glob(["src/test/java/**/*.java"]),
-    deps=[
-      ":lib",
-
-      "@org_junit_jupiter_junit_jupiter_api//jar",
-      "@org_opentest4j_opentest4j//jar",
-    ],
+load("@rules_intellij_generate//:def.bzl", "intellij_iml")
+intellij_iml(
+    name = "iml",
+    java_source=":lib",
+    test_java_source=":test_lib",
 )
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
@@ -25,15 +37,4 @@ junit5_all_in_package_test(
     name="tests",
     java_package="annotation_processor.usage",
     runtime_deps=[":test_lib"]
-)
-
-load("@rules_intellij_generate//:def.bzl", "intellij_iml")
-intellij_iml(
-    name = "iml",
-    compile_lib_deps = [":lib"],
-    test_lib_deps = [":test_lib"],
-    compile_module_deps = [
-        "//05_annotation_processor/class_generator:iml",
-        "//05_annotation_processor/text_file_generator:iml",
-    ],
 )

--- a/scenarios/06_protobuf_messages/usage/BUILD
+++ b/scenarios/06_protobuf_messages/usage/BUILD
@@ -1,27 +1,39 @@
 package(default_visibility = ["//:__subpackages__"])
 
-java_library(
-    name = "lib",
-    srcs = glob(["src/main/java/**/*.java"]),
-    deps = [
-      "//06_protobuf_messages/plain_email:proto_java",
-      "//06_protobuf_messages/html_email:proto_java",
-      "@com_google_protobuf_java//:protobuf_java",
+load("@rules_intellij_generate//:def.bzl",
+    "intellij_source_java_library",
+    "MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP",
+    "MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP")
+
+intellij_source_java_library(
+    name="lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP,
+    deps=[
+        "//06_protobuf_messages/plain_email:proto_java",
+        "//06_protobuf_messages/html_email:proto_java",
+        "@com_google_protobuf_java//:protobuf_java",
+    ]
+)
+
+intellij_source_java_library(
+    name="test_lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP,
+    deps=[
+        ":lib",
+        "//06_protobuf_messages/plain_email:proto_java",
+        "//06_protobuf_messages/html_email:proto_java",
+
+        "@com_google_protobuf_java//:protobuf_java",
+        "@org_junit_jupiter_junit_jupiter_api//jar",
+        "@org_opentest4j_opentest4j//jar",
     ],
 )
 
-java_library(
-    name = "test_lib",
-    srcs = glob(["src/test/java/**/*.java"]),
-    deps=[
-      ":lib",
-      "//06_protobuf_messages/plain_email:proto_java",
-      "//06_protobuf_messages/html_email:proto_java",
-
-      "@com_google_protobuf_java//:protobuf_java",
-      "@org_junit_jupiter_junit_jupiter_api//jar",
-      "@org_opentest4j_opentest4j//jar",
-    ],
+load("@rules_intellij_generate//:def.bzl", "intellij_iml")
+intellij_iml(
+    name = "iml",
+    java_source=":lib",
+    test_java_source=":test_lib",
 )
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
@@ -29,11 +41,4 @@ junit5_all_in_package_test(
     name="tests",
     java_package="protobuf_messages.usage",
     runtime_deps=[":test_lib"]
-)
-
-load("@rules_intellij_generate//:def.bzl", "intellij_iml")
-intellij_iml(
-    name = "iml",
-    compile_lib_deps = [":lib"],
-    test_lib_deps = [":test_lib"],
 )

--- a/scenarios/07_grpc/BUILD
+++ b/scenarios/07_grpc/BUILD
@@ -18,27 +18,39 @@ java_grpc_library(
     srcs = [":proto"],
 )
 
-java_library(
-    name = "lib",
-    srcs = glob(["src/main/java/**/*.java"]),
-    deps = [
-      ":grpc",
-      ":proto_java",
-      "@grpc_java//stub",
+load("@rules_intellij_generate//:def.bzl",
+    "intellij_source_java_library",
+    "MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP",
+    "MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP")
+
+intellij_source_java_library(
+    name="lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP,
+    deps=[
+        ":grpc",
+        ":proto_java",
+        "@grpc_java//stub",
+    ]
+)
+
+intellij_source_java_library(
+    name="test_lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP,
+    deps=[
+        ":lib",
+        ":proto_java",
+        "@grpc_java//stub",
+
+        "@org_junit_jupiter_junit_jupiter_api//jar",
+        "@org_opentest4j_opentest4j//jar",
     ],
 )
 
-java_library(
-    name = "test_lib",
-    srcs = glob(["src/test/java/**/*.java"]),
-    deps=[
-      ":lib",
-      ":proto_java",
-      "@grpc_java//stub",
-
-      "@org_junit_jupiter_junit_jupiter_api//jar",
-      "@org_opentest4j_opentest4j//jar",
-    ],
+load("@rules_intellij_generate//:def.bzl", "intellij_iml")
+intellij_iml(
+    name = "iml",
+    java_source=":lib",
+    test_java_source=":test_lib",
 )
 
 load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
@@ -46,13 +58,6 @@ junit5_all_in_package_test(
     name="tests",
     java_package="fortune_grpc",
     runtime_deps=[":test_lib"]
-)
-
-load("@rules_intellij_generate//:def.bzl", "intellij_iml")
-intellij_iml(
-    name = "iml",
-    compile_lib_deps = [":lib"],
-    test_lib_deps = [":test_lib"],
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_modules_xml")

--- a/scenarios/08_auto_value/BUILD
+++ b/scenarios/08_auto_value/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//07_grpc:__subpackages__"])
+package(default_visibility = ["//08_auto_value:__subpackages__"])
 
 # see https://www.kchodorow.com/blog/2016/11/12/using-autovalue-with-bazel/
 java_plugin(
@@ -8,41 +8,36 @@ java_plugin(
     deps = ["@com_google_auto_value//jar"],
 )
 
-java_library(
-    name = "lib",
-    srcs = glob(["src/main/java/**/*.java"]),
-    deps = [
+load("@rules_intellij_generate//:def.bzl",
+    "intellij_source_java_library",
+    "MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP",
+    "MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP")
+
+intellij_source_java_library(
+    name="lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_SOURCE_FOLDER_MAP,
+    deps=[
         "@com_google_auto_value//jar",
         ":autovalue_plugin",
-    ],
+    ]
 )
 
-java_library(
-    name = "test_lib",
-    srcs = glob(["src/test/java/**/*.java"]),
+intellij_source_java_library(
+    name="test_lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP,
     deps=[
-      ":lib",
+        ":lib",
 
-      "@org_junit_jupiter_junit_jupiter_api//jar",
-      "@org_opentest4j_opentest4j//jar",
+        "@org_junit_jupiter_junit_jupiter_api//jar",
+        "@org_opentest4j_opentest4j//jar",
     ],
-)
-
-load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
-junit5_all_in_package_test(
-    name="tests",
-    java_package="house",
-    runtime_deps=[":test_lib"]
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")
 intellij_iml(
     name = "iml",
-    compile_lib_deps = [
-        ":lib",
-        # ":autovalue_plugin",
-    ],
-    test_lib_deps = [":test_lib"],
+    java_source=":lib",
+    test_java_source=":test_lib",
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_modules_xml")
@@ -65,4 +60,11 @@ intellij_project(
   intellij_modules_xml=":modules_xml",
   intellij_compiler_xml=":compiler_xml",
   visibility=["//:__subpackages__"],
+)
+
+load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
+junit5_all_in_package_test(
+    name="tests",
+    java_package="house",
+    runtime_deps=[":test_lib"]
 )

--- a/scenarios/scenario_tests/BUILD
+++ b/scenarios/scenario_tests/BUILD
@@ -3,29 +3,24 @@ package(default_visibility = ["//scenario_tests:__subpackages__"])
 # these tests assert on iml and other build output, and therefore should really
 # have some dependency on those things so that this doesn't execute out of order.
 # but not sure what to do about that at this point.
-java_library(
-    name = "test_lib",
-    srcs = glob(["src/test/java/**/*.java"]),
-    deps=[
-      "@org_junit_jupiter_junit_jupiter_api//jar",
-      "@org_opentest4j_opentest4j//jar",
-    ],
-)
 
-load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
-junit5_all_in_package_test(
-    name="tests",
-    java_package="intellij_generate.scenarios",
-    runtime_deps=[":test_lib"]
+load("@rules_intellij_generate//:def.bzl",
+    "intellij_source_java_library",
+    "MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP")
+
+intellij_source_java_library(
+    name="test_lib",
+    source_folder_to_wildcard_map=MAVEN_STANDARD_JAVA_TEST_FOLDER_MAP,
+    deps=[
+        "@org_junit_jupiter_junit_jupiter_api//jar",
+        "@org_opentest4j_opentest4j//jar",
+    ],
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_iml")
 intellij_iml(
     name = "iml",
-    sources_roots = [],
-    compile_lib_deps = [],
-    test_sources_roots = ["src/test/java"],
-    test_lib_deps = [":test_lib"],
+    test_java_source=":test_lib",
 )
 
 load("@rules_intellij_generate//:def.bzl", "intellij_modules_xml")
@@ -39,4 +34,11 @@ intellij_project(
   name="idea_project",
   intellij_modules_xml=":modules_xml",
   visibility=["//:__subpackages__"]
+)
+
+load("@rules_junit5//:def.bzl", "junit5_all_in_package_test")
+junit5_all_in_package_test(
+    name="tests",
+    java_package="intellij_generate.scenarios",
+    runtime_deps=[":test_lib"]
 )

--- a/scenarios/scenario_tests/src/test/java/intellij_generate/scenarios/S06ProtobufMessagesTest.java
+++ b/scenarios/scenario_tests/src/test/java/intellij_generate/scenarios/S06ProtobufMessagesTest.java
@@ -24,7 +24,8 @@ public class S06ProtobufMessagesTest {
     assertEquals(asList(
       "bazel-out/darwin_x86_64-fastbuild/bin/06_protobuf_messages/plain_email/libproto-speed.jar!/",
       "bazel-out/darwin_x86_64-fastbuild/bin/external/com_google_protobuf_java/libprotobuf_java.jar!/",
-      "bazel-out/darwin_x86_64-fastbuild/bin/06_protobuf_messages/html_email/libproto-speed.jar!/"),
+      "bazel-out/darwin_x86_64-fastbuild/bin/06_protobuf_messages/html_email/libproto-speed.jar!/",
+      "bazel-out/darwin_x86_64-fastbuild/bin/external/com_google_protobuf/libdescriptor_proto-speed.jar!/"),
       removeWorkingDirectory(
         xpathList(usageImlContent, "/module/component/orderEntry[@type='module-library' and not(@scope)]/library/CLASSES/root/@url")));
 


### PR DESCRIPTION
…bly unifying iml and java_library

This makes it so we can cleanly determine what bazel artifacts are, and aren't,
generated by intellij source modules. We want to exclude all of these artifacts
from iml files (this is the code we're editing and compiling etc in the ide,
after all), and include all jar's that are not a result of compilation of these
sources.

This has also caused the iml parallel/redundant hierarchy (i.e., parallel
to the dependencies of various java_library targets) to collapse into a
single hierarchy: because now an iml target is a valid java dependency
in and of itself.

In sum, this set of changes gets rid of a major source of problems/weirdness,
and makes these rules much sounder and terser overall.

an intellij java source rule, that duck-types like a java rule, and so works with other java rules (as a dep). now we have a clean way to figure out what generated jars to exclude when putting together intellij module library lists. yay
extract higher level function, make source folders work
gather up transitive intellij deps so we know what libs to exclude
ability to depend on iml's as if they are java deps. iml's act like their 'compile' java_source dependency
the rules BUILD uses the new source lib style
start stripping out old attribs
use of new intellij_source_java_library across all scenarios. cleans up a lot of weirdness