### PR TITLE
Works with bazel 1.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ out/
 node_modules
 workspace.xml
 .rig_sha1
+.python-version

--- a/README.md
+++ b/README.md
@@ -57,3 +57,16 @@ in your workspace.
 You may want to try this out using the scenarios. Once installed, any scenario should be loadable into Intellij,
 by opening up its directory in the IDE as a new project.
 
+## Python
+
+This project has a dependency on python. For now please make sure you have a python 3 interpreter that's findable 
+by the core-bazel [default toolchain support for python](https://github.com/bazelbuild/rules_python/blob/master/proposals/2019-02-12-design-for-a-python-toolchain.md#default-toolchain).
+
+If you are using pyenv, install a modern 3.X interpreter, and make it findable by the bazel/python default
+toolchain support using:
+
+```
+pyenv global 3.7.0
+```
+
+Where "3.7.0" is the version of your python 3 interpreter.

--- a/rules/private/pytest/rules_intellij_generate_test.py
+++ b/rules/private/pytest/rules_intellij_generate_test.py
@@ -31,7 +31,7 @@ class RulesIntellijGenerateTest(unittest.TestCase):
                     "  </e>",
                     "</a>",
                     ""
-                ]), ET.tostring(xml_indent(a_element)))
+                ]), ET.tostring(xml_indent(a_element)).decode("utf-8"))
 
     def test_iml_paths(self):
         root_intellij_module = {
@@ -78,7 +78,6 @@ class RulesIntellijGenerateTest(unittest.TestCase):
 
     def test_basic_composer_and_conversion_to_xml(self):
         iml_types_xml = """
-<?xml version='1.0' encoding='UTF-8'?>
 <iml-types>
     <iml-type name=\"java\">
         <module>
@@ -93,7 +92,6 @@ class RulesIntellijGenerateTest(unittest.TestCase):
 """.strip()
 
         expected_root_iml_content = """
-<?xml version='1.0' encoding='UTF-8'?>
 <module>
   <component name=\"NewModuleRootManager\">
     <content>
@@ -117,7 +115,6 @@ class RulesIntellijGenerateTest(unittest.TestCase):
 
     def test_insert_jar_dep_into_iml_element_as_module_library(self):
         iml_base_content = """
-<?xml version='1.0' encoding='UTF-8'?>
 <module>
   <component name=\"NewModuleRootManager\">
     <content>
@@ -129,7 +126,6 @@ class RulesIntellijGenerateTest(unittest.TestCase):
 """.strip() + "\n"
 
         expected_content_1 = """
-<?xml version='1.0' encoding='UTF-8'?>
 <module>
   <component name=\"NewModuleRootManager\">
     <content>
@@ -158,7 +154,6 @@ class RulesIntellijGenerateTest(unittest.TestCase):
         self.assertEqual(expected_content_1, convert_xml_element_to_pretty_printed_xml_string(element1))
 
         expected_content_2 = """
-<?xml version='1.0' encoding='UTF-8'?>
 <module>
   <component name=\"NewModuleRootManager\">
     <content>
@@ -188,7 +183,6 @@ class RulesIntellijGenerateTest(unittest.TestCase):
 
     def test_add_jar_libraries(self):
         iml_base_content = """
-<?xml version='1.0' encoding='UTF-8'?>
 <module>
   <component name="NewModuleRootManager">
     <content>
@@ -262,7 +256,6 @@ class RulesIntellijGenerateTest(unittest.TestCase):
         # - libs that are present in both test mode and non-test mode, are considered compile dependencies (so, no scope attribute)
 
         expected_content = """
-<?xml version='1.0' encoding='UTF-8'?>
 <module>
   <component name="NewModuleRootManager">
     <content>
@@ -399,7 +392,6 @@ class RulesIntellijGenerateTest(unittest.TestCase):
 
     def test_insert_bazel_package_dep_into_iml_element_as_module_dep(self):
         iml_base_content = """
-<?xml version='1.0' encoding='UTF-8'?>
 <module>
   <component name=\"NewModuleRootManager\">
     <content>
@@ -411,15 +403,14 @@ class RulesIntellijGenerateTest(unittest.TestCase):
 """.strip() + "\n"
 
         expected_content = """
-<?xml version='1.0' encoding='UTF-8'?>
 <module>
   <component name=\"NewModuleRootManager\">
     <content>
       <existing />
     </content>
     <orderEntry forTests="false" type="sourceFolder" />
-    <orderEntry module-name="bar" type="module" />
-    <orderEntry module-name="zzz" type="module" />
+    <orderEntry exported="" module-name="bar" type="module" />
+    <orderEntry exported="" module-name="zzz" type="module" />
   </component>
 </module>
 """.strip() + "\n"
@@ -432,7 +423,6 @@ class RulesIntellijGenerateTest(unittest.TestCase):
 
     def test_add_bazel_package_deps(self):
         iml_base_content = """
-<?xml version='1.0' encoding='UTF-8'?>
 <module>
   <component name=\"NewModuleRootManager\">
     <content>
@@ -444,15 +434,14 @@ class RulesIntellijGenerateTest(unittest.TestCase):
 """.strip() + "\n"
 
         expected_content = """
-<?xml version='1.0' encoding='UTF-8'?>
 <module>
   <component name=\"NewModuleRootManager\">
     <content>
       <existing />
     </content>
     <orderEntry forTests="false" type="sourceFolder" />
-    <orderEntry module-name="bar" type="module" />
-    <orderEntry module-name="zzz" type="module" />
+    <orderEntry exported="" module-name="bar" type="module" />
+    <orderEntry exported="" module-name="zzz" type="module" />
   </component>
 </module>
 """.strip() + "\n"
@@ -466,7 +455,6 @@ class RulesIntellijGenerateTest(unittest.TestCase):
 
     def test_make_modules_xml(self):
         expected_content = """
-<?xml version='1.0' encoding='UTF-8'?>
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>

--- a/scenarios/WORKSPACE
+++ b/scenarios/WORKSPACE
@@ -23,8 +23,8 @@ junit5_repositories()
 
 http_archive(
     name = "com_google_protobuf",
-    strip_prefix = "protobuf-3.6.1.3",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.6.1.3.tar.gz"],
+    strip_prefix = "protobuf-3.11.0",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.11.0.tar.gz"],
 )
 http_archive(
     name = "com_google_protobuf_javalite",
@@ -34,13 +34,12 @@ http_archive(
 
 http_archive(
     name = "io_grpc_grpc_java",
-    urls = ["https://github.com/grpc/grpc-java/archive/57043233bf5aecce92f0c6629b6ac46d9393ce8c.zip"],
-    strip_prefix = "grpc-java-57043233bf5aecce92f0c6629b6ac46d9393ce8c",
+    urls = ["https://github.com/grpc/grpc-java/archive/fd7d2e5eb4dd020bb892278c78f7b3ef901232c1.zip"],
+    strip_prefix = "grpc-java-fd7d2e5eb4dd020bb892278c78f7b3ef901232c1",
 )
 load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
 grpc_java_repositories(
     omit_com_google_guava=True,
-    omit_io_opencensus_api=True,
     omit_com_google_protobuf=True,
     omit_com_google_protobuf_javalite=True,
 )
@@ -79,18 +78,22 @@ exports_files([
 )
 
 # 12_kotlin
-rules_kotlin_version = "59dc7473c777b5054e91c1af6b95ed0ecbdc0ace" # 2019-04-01
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+rules_kotlin_version = "legacy-1.3.0-rc3"
+rules_kotlin_sha = "54678552125753d9fc0a37736d140f1d2e69778d3e52cf454df41a913b964ede"
 http_archive(
     name = "io_bazel_rules_kotlin",
     urls = ["https://github.com/bazelbuild/rules_kotlin/archive/%s.zip" % rules_kotlin_version],
     type = "zip",
-    strip_prefix = "rules_kotlin-%s" % rules_kotlin_version
+    strip_prefix = "rules_kotlin-%s" % rules_kotlin_version,
+    sha256 = rules_kotlin_sha,
 )
 
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
 kotlin_repositories()
 kt_register_toolchains()
+
 
 # 15_typescript_rules_multi_tsc
 new_local_repository(
@@ -122,11 +125,26 @@ filegroup(
 """
 )
 
-rules_multi_tsc_version = "b4976c44357323aa6a69e26d8cee9ecc31a32fa1"
+rules_multi_tsc_version = "b532865f32eff58338f6a9822adaa7d3142c845d"
 
 http_archive(
     name = "rules_multi_tsc",
     urls = ["https://github.com/sconover/rules_multi_tsc/archive/%s.zip" % rules_multi_tsc_version],
     type = "zip",
     strip_prefix = "rules_multi_tsc-%s/rules" % rules_multi_tsc_version
+)
+
+http_archive(
+    name = "rules_python",
+    sha256 = "e5470e92a18aa51830db99a4d9c492cc613761d5bdb7131c04bd92b9834380f6",
+    strip_prefix = "rules_python-4b84ad270387a7c439ebdccfd530e2339601ef27",
+    urls = ["https://github.com/bazelbuild/rules_python/archive/4b84ad270387a7c439ebdccfd530e2339601ef27.tar.gz"],
+)
+
+http_archive(
+    name = "zlib",
+    build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
+    sha256 = "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff",
+    strip_prefix = "zlib-1.2.11",
+    urls = ["https://github.com/madler/zlib/archive/v1.2.11.tar.gz"],
 )

--- a/scenarios/scenario_tests/pytest/s06_protobuf_messages_test.py
+++ b/scenarios/scenario_tests/pytest/s06_protobuf_messages_test.py
@@ -1,8 +1,9 @@
 import unittest
+
 from scenario_test_support import *
 
-class S06ProtobufMessagesTest(unittest.TestCase):
 
+class S06ProtobufMessagesTest(unittest.TestCase):
     archive = load_archive("06_protobuf_messages/intellij_files")
 
     usage_iml_content = archive["06_protobuf_messages/usage/usage.iml"]
@@ -10,10 +11,9 @@ class S06ProtobufMessagesTest(unittest.TestCase):
     def test_libraries(self):
         self.assertEqual([
             "jar://${BAZEL_INFO_EXECUTION_ROOT}/bazel-out/darwin-fastbuild/bin/external/com_google_protobuf/libdescriptor_proto-speed.jar!/",
-            "jar://${BAZEL_INFO_EXECUTION_ROOT}/bazel-out/darwin-fastbuild/bin/06_protobuf_messages/plain_email/libproto-speed.jar!/",
             "jar://${BAZEL_INFO_EXECUTION_ROOT}/bazel-out/darwin-fastbuild/bin/06_protobuf_messages/html_email/libproto-speed.jar!/",
+            "jar://${BAZEL_INFO_EXECUTION_ROOT}/bazel-out/darwin-fastbuild/bin/06_protobuf_messages/plain_email/libproto-speed.jar!/",
             "jar://${BAZEL_INFO_EXECUTION_ROOT}/bazel-out/darwin-fastbuild/bin/external/com_google_protobuf/libprotobuf_java.jar!/",
         ], find_all_plain_jar_libraries(self.usage_iml_content))
 
         self.assertEqual(junit5_jars(), find_all_test_jar_libraries(self.usage_iml_content))
-

--- a/scenarios/scenario_tests/pytest/s07_grpc_test.py
+++ b/scenarios/scenario_tests/pytest/s07_grpc_test.py
@@ -11,21 +11,23 @@ class S07GrpcTest(unittest.TestCase):
 
     def test_libraries(self):
         self.assertEqual([
-            "jar://${BAZEL_INFO_EXECUTION_ROOT}/external/com_google_errorprone_error_prone_annotations/jar/error_prone_annotations-X.X.X.jar!/",
-            "jar://${BAZEL_INFO_EXECUTION_ROOT}/external/com_google_code_gson_gson/jar/gson-X.X.jar!/",
-            "jar://${BAZEL_INFO_EXECUTION_ROOT}/external/com_google_guava_guava/jar/guava-XX.X.jar!/",
-            "jar://${BAZEL_INFO_EXECUTION_ROOT}/external/com_google_code_findbugs_jsrXXX/jar/jsrXXX-X.X.X.jar!/",
+            "jar://${BAZEL_INFO_EXECUTION_ROOT}/external/com_google_errorprone_error_prone_annotations/error_prone_annotations-X.X.X.jar!/",
+            "jar://${BAZEL_INFO_EXECUTION_ROOT}/external/com_google_guava_failureaccess/failureaccess-X.X.X.jar!/",
+            "jar://${BAZEL_INFO_EXECUTION_ROOT}/external/com_google_code_gson_gson/gson-X.X.X.jar!/",
+            "jar://${BAZEL_INFO_EXECUTION_ROOT}/external/com_google_guava_guava/jar/guava-X.X.jar!/",
+            "jar://${BAZEL_INFO_EXECUTION_ROOT}/external/com_google_jXobjc_jXobjc_annotations/jXobjc-annotations-X.X.jar!/",
+            "jar://${BAZEL_INFO_EXECUTION_ROOT}/external/com_google_code_findbugs_jsrX/jsrX-X.X.X.jar!/",
+            "jar://${BAZEL_INFO_EXECUTION_ROOT}/bazel-out/darwin-fastbuild/bin/external/io_grpc_grpc_java/api/libapi.jar!/",
             "jar://${BAZEL_INFO_EXECUTION_ROOT}/bazel-out/darwin-fastbuild/bin/external/io_grpc_grpc_java/context/libcontext.jar!/",
-            "jar://${BAZEL_INFO_EXECUTION_ROOT}/bazel-out/darwin-fastbuild/bin/external/io_grpc_grpc_java/core/libcore.jar!/",
             "jar://${BAZEL_INFO_EXECUTION_ROOT}/bazel-out/darwin-fastbuild/bin/external/com_google_protobuf/libdescriptor_proto-speed.jar!/",
-            "jar://${BAZEL_INFO_EXECUTION_ROOT}/bazel-out/darwin-fastbuild/bin/XX_grpc/libjava_grpc.jar!/",
-            "jar://${BAZEL_INFO_EXECUTION_ROOT}/bazel-out/darwin-fastbuild/bin/XX_grpc/libproto-speed.jar!/",
+            "jar://${BAZEL_INFO_EXECUTION_ROOT}/bazel-out/darwin-fastbuild/bin/X_grpc/libjava_grpc.jar!/",
+            "jar://${BAZEL_INFO_EXECUTION_ROOT}/bazel-out/darwin-fastbuild/bin/X_grpc/libproto-speed.jar!/",
             "jar://${BAZEL_INFO_EXECUTION_ROOT}/bazel-out/darwin-fastbuild/bin/external/io_grpc_grpc_java/protobuf-lite/libprotobuf-lite.jar!/",
             "jar://${BAZEL_INFO_EXECUTION_ROOT}/bazel-out/darwin-fastbuild/bin/external/io_grpc_grpc_java/protobuf/libprotobuf.jar!/",
             "jar://${BAZEL_INFO_EXECUTION_ROOT}/bazel-out/darwin-fastbuild/bin/external/com_google_protobuf/libprotobuf_java.jar!/",
             "jar://${BAZEL_INFO_EXECUTION_ROOT}/bazel-out/darwin-fastbuild/bin/external/com_google_protobuf/libprotobuf_java_util.jar!/",
             "jar://${BAZEL_INFO_EXECUTION_ROOT}/bazel-out/darwin-fastbuild/bin/external/io_grpc_grpc_java/stub/libstub.jar!/",
-            "jar://${BAZEL_INFO_EXECUTION_ROOT}/external/com_google_api_grpc_proto_google_common_protos/jar/proto-google-common-protos-X.X.X.jar!/",
-        ], map(lambda x: re.sub(r"[0-9]", "X", x), find_all_plain_jar_libraries(self.fortune_grpc_iml_content)))
+            "jar://${BAZEL_INFO_EXECUTION_ROOT}/external/com_google_api_grpc_proto_google_common_protos/proto-google-common-protos-X.X.X.jar!/",
+        ], list(map(lambda x: re.sub(r"[0-9]+", "X", x), find_all_plain_jar_libraries(self.fortune_grpc_iml_content))))
 
         self.assertEqual(junit5_jars(), find_all_test_jar_libraries(self.fortune_grpc_iml_content))

--- a/scenarios/scenario_tests/pytest/s12_kotlin_test.py
+++ b/scenarios/scenario_tests/pytest/s12_kotlin_test.py
@@ -17,7 +17,7 @@ class S12KotlinTest(unittest.TestCase):
     def test_source_folders(self):
         expected = [
             "jar://${BAZEL_INFO_EXECUTION_ROOT}/external/com_google_guava_guava/jar/guava-19.0.jar!/",
-            "jar://${BAZEL_INFO_EXECUTION_ROOT}/external/com_github_jetbrains_kotlin/lib/kotlin-runtime.jar!/",
+            "jar://${BAZEL_INFO_EXECUTION_ROOT}/external/com_github_jetbrains_kotlin/lib/kotlin-stdlib.jar!/",
         ]
 
         self.assertEqual(expected, find_all_plain_jar_libraries(self.child_iml_content))

--- a/scenarios/scenario_tests/pytest/scenario_test_support.py
+++ b/scenarios/scenario_tests/pytest/scenario_test_support.py
@@ -25,7 +25,7 @@ def xpath_list(xml_str, xpath):
 
 # unfortunately ElementTree doesn't handle returning xpath attribute values, this is a workaround.
 def xpath_attribute_list(xml_str, xpath, attribute_name):
-    return map(lambda e: e.get(attribute_name), parse_xml(xml_str).findall(xpath))
+    return list(map(lambda e: e.get(attribute_name), parse_xml(xml_str).findall(xpath)))
 
 
 def generated_file_path(relative_path):
@@ -49,14 +49,14 @@ def load_archive(intellij_files_archive_path):
     return relative_path_to_content
 
 def find_all_plain_jar_libraries(iml_content):
-    return map(lambda e: e.find("./library/CLASSES/root").get("url"),
+    return list(map(lambda e: e.find("./library/CLASSES/root").get("url"),
         filter(lambda e: e.get("type") == "module-library" and "scope" not in e.keys(),
-               parse_xml(iml_content).findall("./component/orderEntry")))
+               parse_xml(iml_content).findall("./component/orderEntry"))))
 
 def find_all_test_jar_libraries(iml_content):
-    return map(lambda e: e.find("./library/CLASSES/root").get("url"),
+    return list(map(lambda e: e.find("./library/CLASSES/root").get("url"),
         filter(lambda e: e.get("type") == "module-library" and e.get("scope") == "TEST",
-               parse_xml(iml_content).findall("./component/orderEntry")))
+               parse_xml(iml_content).findall("./component/orderEntry"))))
 
 def junit5_jars():
     return [


### PR DESCRIPTION
upgrade some deps
all tests except scenario 06 / protobuf run using 'bazel test //... --incompatible_strict_action_env'
python 3 -ify the install script
python 3 upgrade, instructions for using the bazel python default toolchain
opencensus