### PR TITLE
Add argument bazelexe to intellij_project

### DIFF
--- a/rules/private/install_intellij_files.py.template
+++ b/rules/private/install_intellij_files.py.template
@@ -51,7 +51,7 @@ custom_substitutions = {
 # Execute "bazel info", and transform the variable names in the output into
 # BAZEL_INFO_VARIABLE_NAME style.
 bazel_info = {}
-for line in get_subcommand_output(["bazel", "info"]).splitlines():
+for line in get_subcommand_output(["_BAZELEXE_", "info"]).splitlines():
     parts = map(lambda part: part.strip(), line.split(":", 1))
     key = "BAZEL_INFO_" + parts[0].upper().replace("-", "_")
     value = parts[1]

--- a/rules/private/intellij_project.bzl
+++ b/rules/private/intellij_project.bzl
@@ -269,7 +269,8 @@ def _impl(ctx):
         output=ctx.outputs.install_intellij_files_script,
         template=ctx.file._install_script_template_file,
         substitutions={
-            "# _CUSTOM_ENV_VARS_GO_HERE": custom_env_vars_str
+            "# _CUSTOM_ENV_VARS_GO_HERE": custom_env_vars_str,
+            "_BAZELEXE_": ctx.attr.bazelexec,
         },
         is_executable=True)
 
@@ -293,6 +294,13 @@ intellij_project = rule(
 
         "_fswatch_and_install_intellij_files_mac_template_file": attr.label(
             default=Label("//private:fswatch_and_install_intellij_files_mac.sh.template"), allow_single_file=True),
+
+        "bazelexec": attr.string(
+            default='bazel',
+            doc="""
+        The install_intellij_files script gets information about the version of bazel you are using.
+        If you are using something like bazelisk, you can specify ./bazelisk instead of a system bazel.
+        """),
 
         "deps": attr.label_list(
             default=[],

--- a/scenarios/13_minor_features/BUILD
+++ b/scenarios/13_minor_features/BUILD
@@ -31,6 +31,7 @@ intellij_module(name="iml", iml_type="java-simple2", module_name_override="13_my
 
 intellij_project(
     name="project_13",
+    bazelexec="my-bazel-script",
     deps=[":java_test_lib"],
     test_lib_label_matchlist=['{"label_name":"java_test_lib"}'],
     custom_substitutions={

--- a/scenarios/scenario_tests/pytest/s13_minor_features_test.py
+++ b/scenarios/scenario_tests/pytest/s13_minor_features_test.py
@@ -1,8 +1,8 @@
 import unittest
 from scenario_test_support import *
 
-class S13MinorFeaturesTest(unittest.TestCase):
 
+class S13MinorFeaturesTest(unittest.TestCase):
     archive = load_archive("13_minor_features/intellij_files")
 
     iml_content = archive["13_minor_features/13_mymodulename.iml"]
@@ -23,6 +23,9 @@ class S13MinorFeaturesTest(unittest.TestCase):
         custom_vars_in_python = script_content.split("# BEFORE_CUSTOM_VARS")[1].split("# AFTER_CUSTOM_VARS")[0]
 
         self.assertEqual(
-            "'MY_BICYCLE_COLOR':'red',\n" +
-            "'SOME_FILE':'13_minor_features/some_file.txt',",
-            custom_vars_in_python.strip())
+                "'MY_BICYCLE_COLOR':'red',\n" +
+                "'SOME_FILE':'13_minor_features/some_file.txt',",
+                custom_vars_in_python.strip())
+
+        self.assertContains(script_content,
+                            'for line in get_subcommand_output(["my-bazel-script", "info"]).splitlines()')


### PR DESCRIPTION
Allows users to specify which bazel executable to use, like bazelisk.